### PR TITLE
deps: pin transitive lodash to 4.18.1 (resolves #195)

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,8 @@
     "dmg-license": "1.0.11"
   },
   "resolutions": {
-    "dompurify": "3.4.10"
+    "dompurify": "3.4.10",
+    "lodash": "4.18.1"
   },
   "repository": "https://github.com/iongion/container-desktop.git"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3108,10 +3108,10 @@ lodash.merge@4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@^4.17.15, lodash@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+lodash@4.18.1, lodash@^4.17.15, lodash@^4.17.21:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 loose-envify@^1.0.0, loose-envify@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
Closes #195.

`lodash` (plain) is a transitive dependency (pulled by immer, react-fast-compare, object-assign) and was still resolving to **4.17.21** in the lockfile, even though the direct `lodash-es` dependency was bumped to 4.18.1 in #197. Dependabot #195 flagged this (proposing 4.17.23).

This adds a yarn `resolutions` entry pinning the transitive `lodash` to **4.18.1** (latest 4.x, consistent with `lodash-es`), which supersedes dependabot's 4.17.23.

Verified: `tsc` + Biome lint + `yarn build` (all configs) green; on-disk `lodash` now 4.18.1.