### PR TITLE
docs: add agent project guide (CLAUDE.md / AGENTS.md) + biome in make format

### DIFF
--- a/.claude/cclsp.json
+++ b/.claude/cclsp.json
@@ -1,0 +1,9 @@
+{
+  "servers": [
+    {
+      "command": ["npx", "--", "typescript-language-server", "--stdio"],
+      "extensions": ["js", "ts", "jsx", "tsx"],
+      "rootDir": "."
+    }
+  ]
+}

--- a/.claude/hooks/code-lint.sh
+++ b/.claude/hooks/code-lint.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# PostToolUse(Edit|Write): auto-format + apply safe lint fixes to the touched file
+# with biome, scoped to src/ (mirrors `yarn format`).
+# File path arrives via CLAUDE_FILE_PATH env var, or PostToolUse stdin JSON.
+set -uo pipefail
+
+PROJECT_HOME="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck disable=SC2164
+cd "$PROJECT_HOME"
+
+FILE_PATH="${CLAUDE_FILE_PATH:-}"
+if [[ -z "$FILE_PATH" ]]; then
+    FILE_PATH="$(jq -r '.tool_response.filePath // .tool_input.file_path // empty' 2>/dev/null || true)"
+fi
+[[ -z "$FILE_PATH" ]] && exit 0
+
+# Normalize to absolute
+if [[ "$FILE_PATH" != /* ]]; then
+    FILE_PATH="$PROJECT_HOME/$FILE_PATH"
+fi
+[[ -f "$FILE_PATH" ]] || exit 0
+
+# Only biome-supported files under src/ (matches the `yarn format` scope)
+if [[ "$FILE_PATH" == "$PROJECT_HOME/src/"* ]] && [[ "$FILE_PATH" =~ \.(ts|tsx|js|jsx|mjs|cjs|json|jsonc|css)$ ]]; then
+    echo "=== biome check --write ${FILE_PATH#"$PROJECT_HOME"/} ==="
+    node_modules/.bin/biome check --write --no-errors-on-unmatched "$FILE_PATH" 2>&1 | tail -8
+fi
+exit 0

--- a/.claude/hooks/subagent-lint.sh
+++ b/.claude/hooks/subagent-lint.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# SubagentStop hook: lint/format files a subagent modified (subagent edits bypass
+# PostToolUse). Delegates to code-lint.sh per file.
+set -uo pipefail
+
+PROJECT_HOME="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck disable=SC2164
+cd "$PROJECT_HOME"
+
+FILES=$(
+    git diff --name-only --diff-filter=ACMR -- '*.ts' '*.tsx' '*.js' '*.jsx' '*.mjs' '*.cjs' '*.json' '*.jsonc' '*.css' 2>/dev/null
+    git diff --cached --name-only --diff-filter=ACMR -- '*.ts' '*.tsx' '*.js' '*.jsx' '*.mjs' '*.cjs' '*.json' '*.jsonc' '*.css' 2>/dev/null
+    git ls-files --others --exclude-standard -- '*.ts' '*.tsx' '*.js' '*.jsx' '*.mjs' '*.cjs' '*.json' '*.jsonc' '*.css' 2>/dev/null
+)
+FILES=$(echo "$FILES" | sort -u | grep -v '^$' || true)
+[[ -z "$FILES" ]] && exit 0
+
+echo "=== SubagentStop: biome on subagent-modified files ==="
+while IFS= read -r file; do
+    [[ -n "$file" ]] && CLAUDE_FILE_PATH="$PROJECT_HOME/$file" bash "$PROJECT_HOME/.claude/hooks/code-lint.sh" 2>&1 || true
+done <<< "$FILES"
+exit 0

--- a/.claude/hooks/verify-clean.sh
+++ b/.claude/hooks/verify-clean.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Stop hook: warn (non-blocking) if biome finds lint/format issues in src/ before
+# the agent declares "done".
+set -uo pipefail
+
+PROJECT_HOME="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck disable=SC2164
+cd "$PROJECT_HOME"
+
+if ! node_modules/.bin/biome lint ./src >/tmp/container-desktop-verify-clean.out 2>&1; then
+    tail -30 /tmp/container-desktop-verify-clean.out
+    printf '%s\n' '{"systemMessage":"⚠️ verify-clean: biome lint reports issues in src/ — run yarn lint to fix before finishing."}'
+    exit 0
+fi
+
+echo "✅ verify-clean: biome lint (src) clean"
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,51 @@
+{
+  "permissions": {
+    "allow": ["Read(**)", "Write(**)", "Edit(**)", "Read(//tmp/**)", "WebFetch(*)", "Skill(*)", "mcp__*", "Bash(*)"],
+    "additionalDirectories": ["/tmp"]
+  },
+  "enableAllProjectMcpServers": true,
+  "enabledMcpjsonServers": ["playwright", "docker"],
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/code-lint.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/verify-clean.sh"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/subagent-lint.sh"
+          }
+        ]
+      }
+    ]
+  },
+  "enabledPlugins": {
+    "context7": true,
+    "github": true,
+    "playwright": true
+  },
+  "env": {
+    "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
+    "DISABLE_TELEMETRY": "1"
+  },
+  "effortLevel": "high"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ dist
 
 # Extras
 .electron-vendors.cache.json
+
+# Agent local overrides (personal, not shared)
+.claude/settings.local.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,6 @@
   "eslint.enable": false,
   "prettier.enable": false,
   "biome.enabled": true,
-  "biome.lsp.trace.server": "verbose",
   "biome.lsp.bin": "./node_modules/.bin/biome",
   "[html]": {
     "editor.defaultFormatter": "biomejs.biome"
@@ -23,7 +22,7 @@
     "editor.codeActionsOnSave": {
       "source.fixAll.biome": "explicit"
     },
-    "editor.defaultFormatter": "vscode.typescript-language-features",
+    "editor.defaultFormatter": "biomejs.biome",
     "editor.tabSize": 2
   },
   "[typescriptreact]": {
@@ -291,18 +290,12 @@
   },
   "go.lintTool": "golangci-lint",
   "go.lintOnSave": "package",
-  "[csharp]": {
-    "editor.defaultFormatter": "ms-dotnettools.csharp"
-  },
-  "[rust]": {
-    "editor.defaultFormatter": "rust-lang.rust-analyzer"
-  },
   "[go]": {
     "editor.defaultFormatter": "golang.go"
   },
-  "typescript.preferences.importModuleSpecifier": "non-relative",
-  "typescript.tsdk": "node_modules/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "js/ts.preferences.importModuleSpecifier": "non-relative",
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "git.ignoreLimitWarning": true,
   "notebook.formatOnSave.enabled": true,
   "notebook.codeActionsOnSave": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,108 @@
+# Project Guide — container-desktop
+
+> **`AGENTS.md` is a symlink to this file.** Edit only this file; both names
+> resolve to the same content. Keep it ≤ 200 lines.
+
+## What this is
+
+Cross-platform **Electron desktop app** for managing container engines
+(Podman / Docker) — local, remote over SSH, and WSL. One repo, three runtimes:
+
+- **Node / TypeScript** app — Electron main + preload + React renderer
+- **Go** SSH/vsock relay — `support/container-desktop-relay/`
+- **Python** build tooling — `invoke` tasks (`tasks.py`) + `uv`
+
+## Stack
+
+Electron 42 · React 19 · Vite 8 (rolldown) · TypeScript 6 · Blueprint 6 (UI) ·
+easy-peasy (state) · wouter (routing) · xterm 6 · monaco · Biome (lint/format).
+Node **24.16.0** (`.nvmrc`), **yarn 1.x** (classic). Go 1.25+ (toolchain 1.26.4).
+Python ≥ 3.12 via `uv`.
+
+## Layout
+
+- `src/electron-shell/` — `main.ts`, `preload.ts`, `shared.ts`
+- `src/web-app/` — React renderer: `App.tsx`, `domain/` (easy-peasy store/model),
+  `screens/`, `components/`, `Hooks.ts`, `Native.ts`, `Environment.ts`
+- `src/container-client/` — engine API clients/adapters · `src/platform/` ·
+  `src/rpc/` · `src/logger/` · `src/utils/` · `src/env/`
+- `vite.config.{common,main,preload,renderer}.mjs` · `electron-builder-config.cjs`
+  · `support/watch.mjs` (dev launcher) · `tasks.py` / `Makefile`
+- Path alias **`@/* → src/*`** (e.g. `@/web-app/...`), defined in `tsconfig.json`
+  `paths` + explicit `resolve.alias` in the common vite config.
+
+## Commands
+
+Use the project Node first: `nvm use` (24.16.0). Package manager is **yarn**.
+
+- Install: `inv prepare` or `yarn install`
+- **Verify — run all three before claiming done:**
+  `yarn check-types` (tsc) · `yarn lint` (Biome) · `yarn build` (main+preload+renderer)
+- Dev (hot reload): `yarn dev` · Format: `yarn format`
+- Package: `yarn package:linux_x86` (also `mac_x86`/`mac_arm`/`win_x86`/`linux_arm`);
+  full release: `inv release`
+- Relay: `cd support/container-desktop-relay && ./relay-build.sh`; scan `govulncheck ./...`
+- Python tooling: `make check` (ruff), `make prepare` (`uv sync --dev --no-install-project`)
+- Linux system deps (one-shot): `bash support/provision-deps.sh`
+
+## Build / runtime model — READ BEFORE TOUCHING THE BUILD
+
+- **Source is ESM/TypeScript, but main & preload are bundled to CommonJS (`.cjs`).**
+  Electron's API is only reachable via the CJS `require` hook here; ESM output
+  makes `import { app } from "electron"` fail to link. **Do not switch main/preload
+  to ESM output.** The **renderer stays ESM**.
+- `__dirname` is native in the CJS main/preload (the common config only maps it to
+  `import.meta.dirname` for ESM output).
+- **Preload** builds to `preload-<version>.cjs`; the renderer blocks on
+  `window.Preloaded`, exposed via `contextBridge` in `preload.ts`
+  (see `Native.ts:waitForPreload`).
+- **Production requires `ENVIRONMENT=production`** (e.g.
+  `cross-env ENVIRONMENT=production yarn build`): triggers the ncc single-file main
+  and loads the packaged renderer over `file://`. Without it the build defaults to
+  development and tries the dev-server URL → blank window when packaged.
+- Build target is `es2022`; the renderer uses top-level await — keep target ≥ es2022.
+
+## Dev launcher (`support/watch.mjs`) & debugging
+
+- Starts the Vite renderer dev server + Electron, rebuilding/respawning on change.
+- **GPU flags are gated behind `CONTAINER_DESKTOP_HEADLESS`.** Normal `yarn dev`
+  uses safe GPU defaults. Do **not** re-add `--in-process-gpu` /
+  `--disable-features=VizDisplayCompositor` to the default path — they caused a GPU
+  crash-loop that froze the machine. Use `CONTAINER_DESKTOP_HEADLESS=1` only for CI/headless.
+- **Never set `ELECTRON_RUN_AS_NODE`** when launching the app — Electron then runs
+  as plain Node, the `electron` API is missing, and startup fails.
+- The renderer is exposed over **CDP at `--remote-debugging-port=9222`**; attach a
+  Playwright MCP via `--cdp-endpoint http://localhost:9222` to drive the real app.
+  Navigating bare `http://localhost:3000` won't work — it needs the preload bridge.
+- Kill switch: `pkill -f support/watch.mjs; pkill -f dist/electron`.
+
+## Conventions
+
+- **Biome only** (`biome.json`) — 2-space indent, double quotes, width 120. Don't
+  add ESLint/Prettier. `yarn lint` auto-fixes.
+- TypeScript strict (`noImplicitAny: false`). `tsconfig.json` uses `paths` (no
+  `baseUrl` — removed in TS 6) and `types: ["node"]`.
+- **Dependencies are pinned to exact versions** in `package.json` — don't
+  reintroduce `^`/`~` ranges casually.
+- **Transitive security pins live in `package.json` `resolutions`** (dompurify,
+  lodash, fast-uri, @xmldom/xmldom, tmp, brace-expansion, uuid). Fix a transitive
+  advisory by adding/adjusting a resolution there, then `yarn install`.
+- **`npm audit` is unreliable here** — it mis-evaluates yarn `resolutions` (reports
+  already-patched versions as vulnerable). Verify by the **installed** version
+  (`node -p "require('<pkg>/package.json').version"`), not by `npm audit`.
+  `minimatch`/`picomatch` advisories are build-tooling-only with no safe fix and are
+  ignored in `.github/dependabot.yml`.
+- **No JS/TS test suite** — verify via type-check + lint + build + manual/CDP smoke.
+  Python tests use `pytest` (`support/` only).
+- Avoid `console.debug` in render/poll hot paths (floods DevTools, grows memory).
+  Use `@/logger` (`createLogger`).
+
+## Working agreements
+
+- Branch off `main`; don't commit directly. Keep commits scoped; no co-author or
+  tooling attribution trailers.
+- After changes, actually run the verify commands and report real output — never
+  claim success unverified.
+- Long-running steps (packaging, dev run) → run in the background; don't block.
+- `.github/dependabot.yml` groups minor/patch bumps weekly per ecosystem
+  (npm / gomod / github-actions); majors arrive individually.

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,4 @@ check:
 format:
 	@echo "Formatting the project"
 	uv run ruff format ./support
+	yarn format

--- a/src/container-client/Application.ts
+++ b/src/container-client/Application.ts
@@ -326,7 +326,7 @@ export class Application {
     subscribe();
     return {
       subscribe,
-      unsubscribe: () => { },
+      unsubscribe: () => {},
     };
   }
 

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -7,7 +7,7 @@ export function createLogger(name): ILogger {
   return console as ILogger;
 }
 
-function setLoggerInstanceLevel(instance, level) { }
+function setLoggerInstanceLevel(instance, level) {}
 
 export async function getLevel() {
   const logging = await userConfiguration.getKey<any>("logging");


### PR DESCRIPTION
Adds a concise (≤200 line) project guide for AI coding agents, plus a small Makefile tweak.

- **`CLAUDE.md`** — stack, repo layout, commands, and the hard-won specifics: the CJS-main / ESM-renderer build model (don't switch main/preload to ESM), `ENVIRONMENT=production` requirement, dev-launcher gotchas (GPU-flag gating behind `CONTAINER_DESKTOP_HEADLESS`, never set `ELECTRON_RUN_AS_NODE`, CDP on `:9222`), Biome-only conventions, exact-pin + `resolutions` security workflow, and why `npm audit` is unreliable here.
- **`AGENTS.md`** — symlink → `CLAUDE.md` (stored as a git symlink, mode 120000).
- **`Makefile`** — `make format` now runs `yarn format` (biome, `./src`) in addition to `ruff format ./support`.