### PR TITLE
ci(dependabot): ignore @types/node major bumps (keep aligned with Node 24)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,12 @@ updates:
           - "minor"
           - "patch"
     ignore:
+      # Keep @types/node aligned with the runtime Node major (24 — see .nvmrc;
+      # Electron 42 also bundles Node 24). A major bump (25.x) would type against
+      # an API surface the runtime doesn't have. Patch/minor 24.x bumps still flow.
+      - dependency-name: "@types/node"
+        update-types:
+          - "version-update:semver-major"
       # Build/dev-tooling-only transitive ReDoS advisories (minimatch via
       # glob/@electron/asar/electron-builder; picomatch via chokidar/anymatch).
       # They are NOT shipped in the app bundle and run on developer-controlled


### PR DESCRIPTION
Keeps `@types/node` on the 24.x line so the type definitions match the runtime (Node 24.16.0 per `.nvmrc`; Electron 42 also bundles Node 24). A major bump to 25.x would type against APIs the runtime doesn't expose.

Patch/minor 24.x bumps still flow normally. Supersedes/closes the auto-opened #206 (@types/node → 25.9.3).