### PR TITLE
fix(deps): patch minimatch/picomatch/ajv ReDoS (in-range) + dependabot blocks majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,10 @@
 # Dependabot configuration — https://docs.github.com/code-security/dependabot
-# Goal: keep dependencies current with minimal PR noise. Minor/patch bumps are
-# grouped into a single PR per ecosystem; majors still arrive as individual PRs
-# so they can be reviewed deliberately.
+# Goal: keep dependencies current with minimal PR noise.
+#   * Minor/patch bumps are grouped into a single PR per ecosystem.
+#   * MAJOR version bumps are never auto-proposed — they are ignored across
+#     every ecosystem and adopted deliberately by hand. In-range minor/patch
+#     security fixes still flow (e.g. the minimatch/picomatch ReDoS patches,
+#     which now exist within each major and keep glob@7 / chokidar@3 working).
 version: 2
 updates:
   # JavaScript / TypeScript (root package.json, yarn)
@@ -16,20 +19,11 @@ updates:
           - "minor"
           - "patch"
     ignore:
-      # Keep @types/node aligned with the runtime Node major (24 — see .nvmrc;
-      # Electron 42 also bundles Node 24). A major bump (25.x) would type against
-      # an API surface the runtime doesn't have. Patch/minor 24.x bumps still flow.
-      - dependency-name: "@types/node"
+      # No automated major upgrades (e.g. @types/node stays on the Node-24 line;
+      # minimatch/picomatch majors would break glob@7 / chokidar@3).
+      - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
-      # Build/dev-tooling-only transitive ReDoS advisories (minimatch via
-      # glob/@electron/asar/electron-builder; picomatch via chokidar/anymatch).
-      # They are NOT shipped in the app bundle and run on developer-controlled
-      # inputs. There is no patched in-major release — the only fix is a major
-      # bump that breaks glob@7 / chokidar@3 (packaging + vite dev watch).
-      # Remove these entries once the upstream tooling updates its matchers.
-      - dependency-name: "minimatch"
-      - dependency-name: "picomatch"
 
   # Go SSH relay
   - package-ecosystem: "gomod"
@@ -42,6 +36,10 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
   # GitHub Actions workflows
   - package-ecosystem: "github-actions"
@@ -52,3 +50,7 @@ updates:
       actions-all:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,8 +90,9 @@ Use the project Node first: `nvm use` (24.16.0). Package manager is **yarn**.
 - **`npm audit` is unreliable here** — it mis-evaluates yarn `resolutions` (reports
   already-patched versions as vulnerable). Verify by the **installed** version
   (`node -p "require('<pkg>/package.json').version"`), not by `npm audit`.
-  `minimatch`/`picomatch` advisories are build-tooling-only with no safe fix and are
-  ignored in `.github/dependabot.yml`.
+  `minimatch`/`picomatch` ReDoS advisories are build-tooling-only (not shipped) and
+  now have in-range patches — pulled in by refreshing the lockfile entry, not a
+  `resolution`. Only their breaking majors are blocked (see dependabot, below).
 - **No JS/TS test suite** — verify via type-check + lint + build + manual/CDP smoke.
   Python tests use `pytest` (`support/` only).
 - Avoid `console.debug` in render/poll hot paths (floods DevTools, grows memory).
@@ -105,4 +106,5 @@ Use the project Node first: `nvm use` (24.16.0). Package manager is **yarn**.
   claim success unverified.
 - Long-running steps (packaging, dev run) → run in the background; don't block.
 - `.github/dependabot.yml` groups minor/patch bumps weekly per ecosystem
-  (npm / gomod / github-actions); majors arrive individually.
+  (npm / gomod / github-actions); **major bumps are never auto-proposed** (ignored
+  globally) — adopt majors deliberately by hand.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1263,9 +1263,9 @@ ajv@8.20.0, ajv@^8.18.0:
     require-from-string "^2.0.2"
 
 ajv@^6.10.0:
-  version "6.12.6"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
-  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.15.0.tgz#07e982c74626167aa7a2495c53817892d7139492"
+  integrity sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -1468,7 +1468,7 @@ boolean@^3.0.1:
   resolved "https://registry.yarnpkg.com/boolean/-/boolean-3.2.0.tgz#9e5294af4e98314494cbb17979fa54ca159f116b"
   integrity sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==
 
-brace-expansion@2.0.3, brace-expansion@^1.1.7, brace-expansion@^2.0.1, brace-expansion@^5.0.5:
+brace-expansion@2.0.3, brace-expansion@^1.1.7, brace-expansion@^2.0.1, brace-expansion@^2.0.2, brace-expansion@^5.0.5:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.3.tgz#0493338bdd58e319b1039c67cf7ee439892c01d9"
   integrity sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==
@@ -3224,25 +3224,25 @@ minimatch@^10.0.1, minimatch@^10.2.2, minimatch@^10.2.5:
     brace-expansion "^5.0.5"
 
 minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.5.tgz#580c88f8d5445f2bd6aa8f3cadefa0de79fbd69e"
+  integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
   dependencies:
     brace-expansion "^1.1.7"
 
 minimatch@^5.0.1:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
-  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+  version "5.1.9"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.9.tgz#1293ef15db0098b394540e8f9f744f9fda8dee4b"
+  integrity sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==
   dependencies:
     brace-expansion "^2.0.1"
 
 minimatch@^9.0.3:
-  version "9.0.5"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
-  integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
+  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
   dependencies:
-    brace-expansion "^2.0.1"
+    brace-expansion "^2.0.2"
 
 minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.8"
@@ -3532,16 +3532,11 @@ picocolors@^1.1.1:
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
 picomatch@^2.0.4, picomatch@^2.2.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
-picomatch@^4.0.2:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
-  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
-
-picomatch@^4.0.4:
+picomatch@^4.0.2, picomatch@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
   integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==


### PR DESCRIPTION
## What
Clears all **6 open Dependabot alerts** with **zero breaking changes**, and configures Dependabot to never auto-propose major upgrades.

## The 6 alerts were stale-lockfile artifacts
Each had an in-range patched release that satisfies the caret range already in `yarn.lock` — refreshing those entries pulls the fix while every major keeps working:

| Package | Alert | Was | Now | Consumer kept on major |
|---|---|---|---|---|
| minimatch | ReDoS `<3.1.3` | 3.1.2 | **3.1.5** | glob@7 (`^3`) |
| minimatch | ReDoS `5.0–5.1.8` | 5.1.6 | **5.1.9** | `^5` |
| minimatch | ReDoS `9.0–9.0.7` | 9.0.5 | **9.0.9** | `^9` |
| picomatch | ReDoS `<2.3.2` | 2.3.1 | **2.3.2** | chokidar@3 (`^2`) |
| picomatch | ReDoS `4.0–4.0.4` | 4.0.3 | **4.0.4** | `^4` |
| ajv | ReDoS `<6.14.0` | 6.12.6 | **6.15.0** | dmg-license (`^6`, mac-build-only) |

No `resolutions` needed (those force a single version across majors and *would* break glob@7/chokidar@3). The old "no in-major fix exists" assumption is now outdated — patches exist within every affected major.

## Dependabot: no automated majors
Adds a global `dependency-name: "*"` + `version-update:semver-major` ignore to **npm / gomod / github-actions**, superseding the per-package ignores. Grouped minor/patch bumps (incl. in-range security fixes) still flow.

## Verify
`yarn check-types` ✅ · `yarn lint` ✅ (249 files) · `yarn build` ✅ (production, built in 3.18s). Confirmed no unrelated lock entries changed (brace-expansion stays pinned at 2.0.3).