### PR TITLE
Improve logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The embedded terminal no longer recreates itself on every log update, preventing flicker and duplicate output.
 - Build output is now version-scoped under `build/<version>/` with stable target filenames.
 - Trimmed unused direct dependencies and removed the dead ncc single-file post-build step; ssh-related modules continue to be bundled by the Vite/Rolldown build.
+- Resource detail and inspect views (containers, images, pods, volumes, networks, secrets) now refresh from engine events instead of a 2-second poll, and polling pauses while the window is in the background; the remaining polled views (stats, processes, machines) only refresh while visible.
+- Container statistics are only polled while the container is running.
+- The container logs view shows a live status pill (LIVE / CONNECTING / ENDED / SNAPSHOT) overlaid on the terminal in place of the status bar, and coalesces streamed output per animation frame to stay smooth under heavy logging.
 
 ## Fixed
 

--- a/src/web-app/components/LiveLogBadge.css
+++ b/src/web-app/components/LiveLogBadge.css
@@ -1,0 +1,53 @@
+.LiveLogBadge {
+  position: absolute;
+  top: 10px;
+  right: 14px;
+  z-index: 5;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  pointer-events: none;
+  user-select: none;
+  color: #e6e6e6;
+  background: rgba(20, 20, 20, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(2px);
+}
+.LiveLogBadgeDot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #8a8a8a;
+}
+.LiveLogBadge[data-tone="live"] .LiveLogBadgeDot {
+  background: #15b371;
+}
+.LiveLogBadge[data-tone="connecting"] .LiveLogBadgeDot {
+  background: #d9a300;
+}
+.LiveLogBadge[data-tone="error"] {
+  color: #ff7373;
+}
+.LiveLogBadge[data-tone="error"] .LiveLogBadgeDot {
+  background: #db3737;
+}
+.LiveLogBadge[data-tone="snapshot"] .LiveLogBadgeDot {
+  background: #5c7080;
+}
+.LiveLogBadge[data-pulsing="true"] .LiveLogBadgeDot {
+  animation: liveLogPulse 1.4s ease-in-out infinite;
+}
+@keyframes liveLogPulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
+}

--- a/src/web-app/components/LiveLogBadge.test.ts
+++ b/src/web-app/components/LiveLogBadge.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { describeLogStatus } from "./LiveLogBadge";
+
+describe("describeLogStatus", () => {
+  it("maps live to a pulsing LIVE pill", () => {
+    expect(describeLogStatus("live")).toEqual({ label: "LIVE", tone: "live", pulsing: true });
+  });
+  it("maps connecting to a pulsing CONNECTING pill", () => {
+    expect(describeLogStatus("connecting")).toEqual({ label: "CONNECTING", tone: "connecting", pulsing: true });
+  });
+  it("maps ended to a static ENDED pill", () => {
+    expect(describeLogStatus("ended")).toEqual({ label: "ENDED", tone: "ended", pulsing: false });
+  });
+  it("maps error to a static ERROR pill", () => {
+    expect(describeLogStatus("error")).toEqual({ label: "ERROR", tone: "error", pulsing: false });
+  });
+  it("maps snapshot to a static SNAPSHOT pill", () => {
+    expect(describeLogStatus("snapshot")).toEqual({ label: "SNAPSHOT", tone: "snapshot", pulsing: false });
+  });
+});

--- a/src/web-app/components/LiveLogBadge.tsx
+++ b/src/web-app/components/LiveLogBadge.tsx
@@ -1,0 +1,34 @@
+import "./LiveLogBadge.css";
+
+export type LogStatus = "connecting" | "live" | "ended" | "error" | "snapshot";
+
+export interface LogBadgeDescriptor {
+  label: string;
+  tone: LogStatus;
+  pulsing: boolean;
+}
+
+export function describeLogStatus(status: LogStatus): LogBadgeDescriptor {
+  switch (status) {
+    case "live":
+      return { label: "LIVE", tone: "live", pulsing: true };
+    case "connecting":
+      return { label: "CONNECTING", tone: "connecting", pulsing: true };
+    case "ended":
+      return { label: "ENDED", tone: "ended", pulsing: false };
+    case "error":
+      return { label: "ERROR", tone: "error", pulsing: false };
+    default:
+      return { label: "SNAPSHOT", tone: "snapshot", pulsing: false };
+  }
+}
+
+export const LiveLogBadge: React.FC<{ status: LogStatus }> = ({ status }) => {
+  const { label, tone, pulsing } = describeLogStatus(status);
+  return (
+    <div className="LiveLogBadge" data-tone={tone} data-pulsing={pulsing} aria-live="polite">
+      <span className="LiveLogBadgeDot" />
+      <span className="LiveLogBadgeLabel">{label}</span>
+    </div>
+  );
+};

--- a/src/web-app/components/Terminal.tsx
+++ b/src/web-app/components/Terminal.tsx
@@ -8,6 +8,8 @@ import { Terminal as XTermTerminal } from "@xterm/xterm";
 
 import { useEffect, useRef } from "react";
 
+import { createWriteBuffer } from "./terminalWriteBuffer";
+
 import "@xterm/xterm/css/xterm.css";
 
 import "./Terminal.css";
@@ -92,17 +94,20 @@ export const Terminal: React.FC<TerminalProps> = ({ value, writeMode = "append",
     terminal.writeln("If they exist, logs will be displayed shortly");
     term.current = terminal;
     fit.current = fitAddon;
+    const writeBuffer = createWriteBuffer((chunk) => terminal.write(chunk));
     readyCallback.current?.({
       clear: () => {
+        writeBuffer.reset();
         terminal.clear();
         lastValue.current = "";
       },
       fit: () => fitAddon.fit(),
       getTerminal: () => terminal,
-      write: (data) => terminal.write(data as any),
+      write: (data) => writeBuffer.push(toTerminalData(data)),
     });
 
     return () => {
+      writeBuffer.dispose();
       terminal.dispose();
       term.current = null;
       fit.current = null;

--- a/src/web-app/components/Terminal.tsx
+++ b/src/web-app/components/Terminal.tsx
@@ -27,6 +27,7 @@ export interface TerminalProps {
   value?: string | Uint8Array;
   writeMode?: TerminalWriteMode;
   onReady?: (handle: TerminalHandle) => void;
+  overlay?: React.ReactNode;
 }
 
 function toTerminalData(value: string | Uint8Array): string {
@@ -36,7 +37,7 @@ function toTerminalData(value: string | Uint8Array): string {
   return new TextDecoder().decode(value);
 }
 
-export const Terminal: React.FC<TerminalProps> = ({ value, writeMode = "append", onReady }: TerminalProps) => {
+export const Terminal: React.FC<TerminalProps> = ({ value, writeMode = "append", onReady, overlay }: TerminalProps) => {
   const wrapRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<HTMLDivElement | null>(null);
   const term = useRef<XTermTerminal | null>(null);
@@ -153,6 +154,7 @@ export const Terminal: React.FC<TerminalProps> = ({ value, writeMode = "append",
           <div className="TerminalViewContent"></div>
         </ResizeSensor>
       </div>
+      {overlay}
     </div>
   );
 };

--- a/src/web-app/components/terminalWriteBuffer.test.ts
+++ b/src/web-app/components/terminalWriteBuffer.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createWriteBuffer } from "./terminalWriteBuffer";
+
+function manualScheduler() {
+  const queue: Array<(() => void) | null> = [];
+  return {
+    schedule: (cb: () => void) => queue.push(cb),
+    cancel: (handle: number) => {
+      queue[handle - 1] = null;
+    },
+    tick: () => {
+      const items = queue.splice(0);
+      for (const fn of items) fn?.();
+    },
+  };
+}
+
+describe("createWriteBuffer", () => {
+  it("coalesces multiple pushes within a frame into one flush", () => {
+    const flush = vi.fn();
+    const s = manualScheduler();
+    const buf = createWriteBuffer(flush, s.schedule, s.cancel);
+    buf.push("a");
+    buf.push("b");
+    buf.push("c");
+    expect(flush).not.toHaveBeenCalled();
+    s.tick();
+    expect(flush).toHaveBeenCalledTimes(1);
+    expect(flush).toHaveBeenCalledWith("abc");
+  });
+
+  it("reschedules for pushes in a later frame", () => {
+    const flush = vi.fn();
+    const s = manualScheduler();
+    const buf = createWriteBuffer(flush, s.schedule, s.cancel);
+    buf.push("x");
+    s.tick();
+    buf.push("y");
+    s.tick();
+    expect(flush.mock.calls).toEqual([["x"], ["y"]]);
+  });
+
+  it("flushNow flushes synchronously and clears the schedule", () => {
+    const flush = vi.fn();
+    const s = manualScheduler();
+    const buf = createWriteBuffer(flush, s.schedule, s.cancel);
+    buf.push("now");
+    buf.flushNow();
+    expect(flush).toHaveBeenCalledWith("now");
+    s.tick();
+    expect(flush).toHaveBeenCalledTimes(1);
+  });
+
+  it("reset drops pending without flushing but stays usable", () => {
+    const flush = vi.fn();
+    const s = manualScheduler();
+    const buf = createWriteBuffer(flush, s.schedule, s.cancel);
+    buf.push("drop");
+    buf.reset();
+    s.tick();
+    expect(flush).not.toHaveBeenCalled();
+    buf.push("keep");
+    s.tick();
+    expect(flush).toHaveBeenCalledWith("keep");
+  });
+
+  it("dispose makes push a no-op", () => {
+    const flush = vi.fn();
+    const s = manualScheduler();
+    const buf = createWriteBuffer(flush, s.schedule, s.cancel);
+    buf.dispose();
+    buf.push("z");
+    s.tick();
+    expect(flush).not.toHaveBeenCalled();
+  });
+});

--- a/src/web-app/components/terminalWriteBuffer.ts
+++ b/src/web-app/components/terminalWriteBuffer.ts
@@ -1,0 +1,63 @@
+// A tiny write coalescer for xterm: batches many small stream chunks into one terminal.write()
+// per animation frame. Prevents xterm thrashing (and any residual flicker) under high log volume.
+// The scheduler is injectable so it is unit-testable without a real animation frame.
+
+export interface WriteBuffer {
+  push: (data: string) => void;
+  flushNow: () => void;
+  reset: () => void;
+  dispose: () => void;
+}
+
+export function createWriteBuffer(
+  flush: (joined: string) => void,
+  schedule: (cb: () => void) => number = (cb) => requestAnimationFrame(cb),
+  cancel: (handle: number) => void = (handle) => cancelAnimationFrame(handle),
+): WriteBuffer {
+  let pending: string[] = [];
+  let handle: number | null = null;
+  let disposed = false;
+
+  const clearScheduled = () => {
+    if (handle !== null) {
+      cancel(handle);
+      handle = null;
+    }
+  };
+
+  const drain = () => {
+    handle = null;
+    if (pending.length === 0) {
+      return;
+    }
+    const joined = pending.join("");
+    pending = [];
+    flush(joined);
+  };
+
+  const reset = () => {
+    clearScheduled();
+    pending = [];
+  };
+
+  return {
+    push(data: string) {
+      if (disposed || !data) {
+        return;
+      }
+      pending.push(data);
+      if (handle === null) {
+        handle = schedule(drain);
+      }
+    },
+    flushNow() {
+      clearScheduled();
+      drain();
+    },
+    reset,
+    dispose() {
+      reset();
+      disposed = true;
+    },
+  };
+}

--- a/src/web-app/domain/queryClient.ts
+++ b/src/web-app/domain/queryClient.ts
@@ -43,15 +43,17 @@ export const queryClient = new QueryClient({
 // the existing env polling flag (off in development), matching the previous screen poller behaviour. Spread into
 // the relevant useQuery options: useQuery({ queryKey, queryFn, ...liveQueryOptions() }).
 export const liveQueryOptions = (refetchIntervalMs: number = POLL_RATE_DEFAULT) => {
-  // Annotated so the disabled case stays the `false` literal (not widened to `boolean`, which
-  // react-query's refetchInterval rejects); the rest are primitives assignable to any useQuery<T>.
+  // Reserved for genuinely-live, event-less data (stats/processes/machines). Cache-first like the
+  // global default: no background polling, no focus refetch — TanStack already pauses the interval
+  // when the page is hidden (refetchIntervalInBackground:false) and stops polling for unmounted
+  // screens, so this is implicitly scoped to "the screen you're looking at".
   const refetchInterval: number | false = CurrentEnvironment.features.polling?.enabled ? refetchIntervalMs : false;
   return {
     staleTime: 0,
     refetchInterval,
-    refetchIntervalInBackground: true,
+    refetchIntervalInBackground: false,
     refetchOnMount: true,
-    refetchOnWindowFocus: true,
+    refetchOnWindowFocus: false,
     refetchOnReconnect: true,
   };
 };

--- a/src/web-app/screens/Container/LogsScreen.css
+++ b/src/web-app/screens/Container/LogsScreen.css
@@ -3,10 +3,3 @@
   color: #ccc;
   line-height: 1.4em;
 }
-
-.ContainerLogsStatus {
-  align-items: center;
-  display: flex;
-  gap: 8px;
-  padding: 8px 10px 0;
-}

--- a/src/web-app/screens/Container/LogsScreen.tsx
+++ b/src/web-app/screens/Container/LogsScreen.tsx
@@ -1,7 +1,8 @@
-import { Callout, Tag } from "@blueprintjs/core";
+import { Callout } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import { useCallback } from "react";
 import { isContainerRunning } from "@/container-client/adapters/containers";
+import { LiveLogBadge, type LogStatus } from "@/web-app/components/LiveLogBadge";
 import { ScreenLoader } from "@/web-app/components/ScreenLoader";
 import { Terminal } from "@/web-app/components/Terminal";
 import { useRouteParams } from "@/web-app/Navigator";
@@ -39,20 +40,21 @@ export const Screen: AppScreen<ScreenProps> = () => {
     return <ScreenLoader screen={ID} pending={pending} />;
   }
 
+  const badgeStatus: LogStatus = running ? (stream.status === "idle" ? "connecting" : stream.status) : "snapshot";
+
   return (
     <div className="AppScreen" data-screen={ID}>
       <ScreenHeader container={container} currentScreen={ID} onReload={onScreenReload} />
       <div className="AppScreenContent">
-        <div className="ContainerLogsStatus">
-          <Tag minimal icon={running ? IconNames.PULSE : IconNames.STOP} intent={running ? "success" : "none"}>
-            {running ? `Live logs: ${stream.status}` : "Stopped container: snapshot logs"}
-          </Tag>
-        </div>
         {stream.error ? <Callout intent="warning">Live log stream failed: {stream.error}</Callout> : null}
         {running ? (
-          <Terminal writeMode="append" onReady={stream.setTerminal} />
+          <Terminal writeMode="append" onReady={stream.setTerminal} overlay={<LiveLogBadge status={badgeStatus} />} />
         ) : (
-          <Terminal value={logsQuery.data || container.Logs} writeMode="replace" />
+          <Terminal
+            value={logsQuery.data || container.Logs}
+            writeMode="replace"
+            overlay={<LiveLogBadge status="snapshot" />}
+          />
         )}
       </div>
     </div>

--- a/src/web-app/screens/Container/StatsScreen.tsx
+++ b/src/web-app/screens/Container/StatsScreen.tsx
@@ -3,6 +3,7 @@ import { IconNames } from "@blueprintjs/icons";
 import prettyBytes from "pretty-bytes";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
+import { isContainerRunning } from "@/container-client/adapters/containers";
 import { ScreenLoader } from "@/web-app/components/ScreenLoader";
 import { useRouteParams } from "@/web-app/Navigator";
 import { useAppStore } from "@/web-app/stores/appStore";
@@ -22,8 +23,9 @@ export const Screen: AppScreen<ScreenProps> = () => {
   const connectionId = useAppStore((state) => state.currentConnector?.id || "");
   const decodedId = decodeURIComponent(id || "");
   const containerQuery = useContainer(connectionId, decodedId);
-  const statsQuery = useContainerStats(connectionId, decodedId);
   const container = containerQuery.data;
+  const running = isContainerRunning(container);
+  const statsQuery = useContainerStats(connectionId, decodedId, running);
   const stats = statsQuery.data || container?.Stats;
   const pending =
     containerQuery.isLoading || containerQuery.isFetching || statsQuery.isLoading || statsQuery.isFetching;

--- a/src/web-app/screens/Container/queries.ts
+++ b/src/web-app/screens/Container/queries.ts
@@ -27,14 +27,6 @@ export const containerKeys = {
 
 // ── Queries (live) ──
 
-export const useContainersList = (connId: string) =>
-  useQuery({
-    queryKey: containerKeys.list(connId),
-    queryFn: () => new ContainersAdapter().list(),
-    enabled: !!connId,
-    ...liveQueryOptions(),
-  });
-
 export const useContainer = (
   connId: string,
   id?: string,
@@ -42,7 +34,7 @@ export const useContainer = (
   queryOpts?: { live?: boolean; refetchIntervalMs?: number },
 ) => {
   const qc = useQueryClient();
-  const live = queryOpts?.live ?? true;
+  const live = queryOpts?.live ?? false;
   return useQuery({
     queryKey: containerKeys.detail(connId, id ?? ""),
     queryFn: () => new ContainersAdapter().get(id!, opts),
@@ -58,11 +50,11 @@ export const useContainer = (
   });
 };
 
-export const useContainerStats = (connId: string, id?: string) =>
+export const useContainerStats = (connId: string, id?: string, enabled = true) =>
   useQuery({
     queryKey: containerKeys.sub(connId, id ?? "", "stats"),
     queryFn: () => new ContainersAdapter().stats(id!),
-    enabled: !!connId && !!id,
+    enabled: enabled && !!connId && !!id,
     ...liveQueryOptions(),
   });
 
@@ -74,7 +66,11 @@ export const useContainerProcesses = (connId: string, id?: string, enabled = tru
     ...liveQueryOptions(),
   });
 
-export const useContainerLogs = (connId: string, id?: string, opts?: { enabled?: boolean; refetchIntervalMs?: number }) =>
+export const useContainerLogs = (
+  connId: string,
+  id?: string,
+  opts?: { enabled?: boolean; refetchIntervalMs?: number },
+) =>
   useQuery({
     queryKey: containerKeys.sub(connId, id ?? "", "logs"),
     queryFn: () => new ContainersAdapter().logs(id!),

--- a/src/web-app/screens/Image/queries.ts
+++ b/src/web-app/screens/Image/queries.ts
@@ -5,7 +5,6 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Application } from "@/container-client/Application";
 import { type FetchImageOptions, ImagesAdapter, type PushImageOptions } from "@/container-client/adapters/images";
 import type { ContainerImage } from "@/env/Types";
-import { liveQueryOptions } from "@/web-app/domain/queryClient";
 import { resourceEvents } from "@/web-app/stores/resourceEvents";
 
 export type ImageSubKey = "history" | "security";
@@ -18,14 +17,6 @@ export const imageKeys = {
   detail: (connId: string, id: string) => [...imageKeys.details(), connId, id] as const,
   sub: (connId: string, id: string, sub: ImageSubKey) => [...imageKeys.detail(connId, id), sub] as const,
 };
-
-export const useImagesList = (connId: string) =>
-  useQuery({
-    queryKey: imageKeys.list(connId),
-    queryFn: () => new ImagesAdapter().list(),
-    enabled: !!connId,
-    ...liveQueryOptions(),
-  });
 
 export const useImage = (connId: string, id?: string, opts?: FetchImageOptions) => {
   const qc = useQueryClient();
@@ -40,7 +31,6 @@ export const useImage = (connId: string, id?: string, opts?: FetchImageOptions) 
       }
       return undefined;
     },
-    ...liveQueryOptions(),
   });
 };
 

--- a/src/web-app/screens/Network/queries.ts
+++ b/src/web-app/screens/Network/queries.ts
@@ -4,7 +4,6 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { type CreateNetworkOptions, NetworksAdapter } from "@/container-client/adapters/networks";
 import type { Network } from "@/env/Types";
-import { liveQueryOptions } from "@/web-app/domain/queryClient";
 import { resourceEvents } from "@/web-app/stores/resourceEvents";
 
 export const networkKeys = {
@@ -14,14 +13,6 @@ export const networkKeys = {
   details: () => [...networkKeys.all, "detail"] as const,
   detail: (connId: string, name: string) => [...networkKeys.details(), connId, name] as const,
 };
-
-export const useNetworksList = (connId: string) =>
-  useQuery({
-    queryKey: networkKeys.list(connId),
-    queryFn: () => new NetworksAdapter().list(),
-    enabled: !!connId,
-    ...liveQueryOptions(),
-  });
 
 export const useNetwork = (connId: string, name?: string) => {
   const qc = useQueryClient();
@@ -36,7 +27,6 @@ export const useNetwork = (connId: string, name?: string) => {
       }
       return undefined;
     },
-    ...liveQueryOptions(),
   });
 };
 

--- a/src/web-app/screens/Pod/queries.ts
+++ b/src/web-app/screens/Pod/queries.ts
@@ -20,14 +20,6 @@ export const podKeys = {
   sub: (connId: string, id: string, sub: PodSubKey) => [...podKeys.detail(connId, id), sub] as const,
 };
 
-export const usePodsList = (connId: string) =>
-  useQuery({
-    queryKey: podKeys.list(connId),
-    queryFn: () => new PodsAdapter().list(),
-    enabled: !!connId,
-    ...liveQueryOptions(),
-  });
-
 export const usePod = (connId: string, id?: string) => {
   const qc = useQueryClient();
   return useQuery({
@@ -41,7 +33,6 @@ export const usePod = (connId: string, id?: string) => {
       }
       return undefined;
     },
-    ...liveQueryOptions(),
   });
 };
 

--- a/src/web-app/screens/Secret/queries.ts
+++ b/src/web-app/screens/Secret/queries.ts
@@ -4,7 +4,6 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { type CreateSecretOptions, SecretsAdapter } from "@/container-client/adapters/secrets";
 import type { Secret } from "@/env/Types";
-import { liveQueryOptions } from "@/web-app/domain/queryClient";
 import { resourceEvents } from "@/web-app/stores/resourceEvents";
 
 export const secretKeys = {
@@ -14,14 +13,6 @@ export const secretKeys = {
   details: () => [...secretKeys.all, "detail"] as const,
   detail: (connId: string, nameOrId: string) => [...secretKeys.details(), connId, nameOrId] as const,
 };
-
-export const useSecretsList = (connId: string) =>
-  useQuery({
-    queryKey: secretKeys.list(connId),
-    queryFn: () => new SecretsAdapter().list(),
-    enabled: !!connId,
-    ...liveQueryOptions(),
-  });
 
 export const useSecret = (connId: string, nameOrId?: string) => {
   const qc = useQueryClient();
@@ -36,7 +27,6 @@ export const useSecret = (connId: string, nameOrId?: string) => {
       }
       return undefined;
     },
-    ...liveQueryOptions(),
   });
 };
 

--- a/src/web-app/screens/Volume/queries.ts
+++ b/src/web-app/screens/Volume/queries.ts
@@ -4,7 +4,6 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { type CreateVolumeOptions, VolumesAdapter } from "@/container-client/adapters/volumes";
 import type { Volume } from "@/env/Types";
-import { liveQueryOptions } from "@/web-app/domain/queryClient";
 import { resourceEvents } from "@/web-app/stores/resourceEvents";
 
 export const volumeKeys = {
@@ -14,14 +13,6 @@ export const volumeKeys = {
   details: () => [...volumeKeys.all, "detail"] as const,
   detail: (connId: string, nameOrId: string) => [...volumeKeys.details(), connId, nameOrId] as const,
 };
-
-export const useVolumesList = (connId: string) =>
-  useQuery({
-    queryKey: volumeKeys.list(connId),
-    queryFn: () => new VolumesAdapter().list(),
-    enabled: !!connId,
-    ...liveQueryOptions(),
-  });
 
 export const useVolume = (connId: string, nameOrId?: string) => {
   const qc = useQueryClient();
@@ -36,7 +27,6 @@ export const useVolume = (connId: string, nameOrId?: string) => {
       }
       return undefined;
     },
-    ...liveQueryOptions(),
   });
 };
 

--- a/src/web-app/stores/resourceEvents.ts
+++ b/src/web-app/stores/resourceEvents.ts
@@ -7,6 +7,7 @@ import { getActiveHostClient } from "@/container-client/adapters/shared";
 import { VolumesAdapter } from "@/container-client/adapters/volumes";
 import type { HostClientFacade } from "@/container-client/runtimes/facade";
 import { createLogger } from "@/logger";
+import { queryClient } from "@/web-app/domain/queryClient";
 import {
   RESOURCE_DOMAINS,
   type ResourceDomain,
@@ -177,6 +178,10 @@ export class ResourceEventManager {
     try {
       const items = await this.loadDomain(host, domain);
       useResourceStore.getState().setSnapshot(connectionId, domain, items);
+      // Bridge: engine events (and mutations) that refresh the store also invalidate the
+      // TanStack cache for this domain, so open detail/inspect screens refetch on real
+      // events instead of blind polling. Partial-match key = [domain] root.
+      queryClient.invalidateQueries({ queryKey: [domain] });
     } catch (error: any) {
       logger.warn("Unable to refresh resource snapshot", { connectionId, domain, error });
       useResourceStore.getState().setStatus(connectionId, domain, {


### PR DESCRIPTION
## Changed

- Container logs now use a live stream for running containers instead of polling full log snapshots, and stopped containers load logs once until manually refreshed.
- The embedded terminal no longer recreates itself on every log update, preventing flicker and duplicate output.
- Build output is now version-scoped under `build/<version>/` with stable target filenames.
- Trimmed unused direct dependencies and removed the dead ncc single-file post-build step; ssh-related modules continue to be bundled by the Vite/Rolldown build.
- Resource detail and inspect views (containers, images, pods, volumes, networks, secrets) now refresh from engine events instead of a 2-second poll, and polling pauses while the window is in the background; the remaining polled views (stats, processes, machines) only refresh while visible.
- Container statistics are only polled while the container is running.
- The container logs view shows a live status pill (LIVE / CONNECTING / ENDED / SNAPSHOT) overlaid on the terminal in place of the status bar, and coalesces streamed output per animation frame to stay smooth under heavy logging.

## Fixed

- Container logs now decode Docker multiplexed stdout/stderr frames before writing to the terminal.
- The development watcher no longer deletes `preload.cjs` after the preload build completes.
- Monaco is bundled locally instead of being loaded from a CDN.