### PR TITLE
feat: notification center + activity log drawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
+- Notification Center: a right-side panel opened from a bell in the footer, with a notifications history and a filterable Activity log of engine API and CLI interactions (friendly labels, status, duration, copy-as-cURL/command). In-memory only.
 - Find in the current view with **Ctrl+F / Cmd+F** — a themed find widget (match counter, previous/next, case-sensitive) that highlights matches on container logs, inspect, processes and other detail and list views. JSON/YAML editors keep their built-in find, and list screens focus their existing filter box.
 - Configurable monospace font in Settings (family, size and weight): choose any font installed on your system, or reset to the bundled font in one click.
 

--- a/src/container-client/Api.clients.ts
+++ b/src/container-client/Api.clients.ts
@@ -7,7 +7,8 @@ import {
   type EngineConnectorApiSettings,
   OperatingSystem,
 } from "@/env/Types";
-import { deepMerge } from "@/utils";
+import { axiosConfigToCURL, deepMerge } from "@/utils";
+import { systemNotifier } from "./notifier";
 
 export async function getApiConfig(
   api: EngineConnectorApiSettings,
@@ -48,6 +49,44 @@ export async function getApiConfig(
   return config;
 }
 
+// ── Activity Log instrumentation ───────────────────────────────────────────────────────
+// Every engine API call funnels through createApplicationApiDriver.request(); we emit a
+// "pending" entry immediately and patch a "settled" entry (status + duration) by guid so
+// long calls surface at once. The request body is stringified + truncated for memory; the
+// response body is intentionally not captured.
+const ACTIVITY_MAX_BODY = 8 * 1024;
+
+function activityStringify(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+function activityTruncate(text: string | undefined): string | undefined {
+  if (!text) return text;
+  return text.length > ACTIVITY_MAX_BODY ? `${text.slice(0, ACTIVITY_MAX_BODY)}… (${text.length} bytes)` : text;
+}
+function activityCurl(req: any, connection: Connection): string | undefined {
+  try {
+    const api = connection?.settings?.api;
+    const curl = axiosConfigToCURL({
+      baseURL: api?.baseURL,
+      socketPath: api?.connection?.uri,
+      url: req?.url,
+      method: req?.method,
+      params: req?.params,
+      headers: req?.headers,
+      data: req?.data,
+    });
+    return Array.isArray(curl) ? curl.join(" ") : curl;
+  } catch {
+    return undefined;
+  }
+}
+
 export function createApplicationApiDriver(connection: Connection, context?: any): AxiosInstance {
   async function request<_T = any, _DD = any>(request, config?: AxiosRequestConfig<any> | undefined) {
     const req = (config ? deepMerge({}, request, config) : request) || {
@@ -58,7 +97,41 @@ export function createApplicationApiDriver(connection: Connection, context?: any
       return acc;
     }, {} as any);
     req.headers = headersFlat as any;
-    return await Command.ProxyRequest(req, connection, context);
+
+    const guid = crypto.randomUUID();
+    const method = `${req.method || "GET"}`.toUpperCase();
+    const url = `${req.url || ""}`;
+    const startedAt = performance.now();
+    systemNotifier.transmit("activity.api", { phase: "pending", guid, method, url });
+    try {
+      const response = await Command.ProxyRequest(req, connection, context);
+      systemNotifier.transmit("activity.api", {
+        phase: "settled",
+        guid,
+        method,
+        url,
+        status: "ok",
+        httpStatus: response?.status,
+        durationMs: Math.round(performance.now() - startedAt),
+        requestBody: activityTruncate(activityStringify(req.data)),
+        curl: activityCurl(req, connection),
+      });
+      return response;
+    } catch (error: any) {
+      systemNotifier.transmit("activity.api", {
+        phase: "settled",
+        guid,
+        method,
+        url,
+        status: "error",
+        httpStatus: error?.response?.status,
+        durationMs: Math.round(performance.now() - startedAt),
+        error: `${error?.message || error}`,
+        requestBody: activityTruncate(activityStringify(req.data)),
+        curl: activityCurl(req, connection),
+      });
+      throw error;
+    }
   }
   const driver: AxiosInstance = {
     request,

--- a/src/electron-shell/activityBus.ts
+++ b/src/electron-shell/activityBus.ts
@@ -1,0 +1,165 @@
+// Preload-side CLI activity capture. Runs in the Node-capable preload realm and wraps the
+// Command object BEFORE it is exposed to the renderer, timing each CLI invocation and
+// pushing plain, structured-cloneable entries to renderer subscribers over the
+// contextBridge `ActivityBus`.
+//
+// Keep this CJS-safe: no ESM-only deps, no top-level await, no React/web-app imports — it
+// is bundled into preload.cjs. Every emitted payload must be structured-cloneable
+// (primitives / strings / string[] only) because it crosses the contextBridge.
+
+type Subscriber = (entry: any) => void;
+
+const subscribers = new Set<Subscriber>();
+let enabled = true;
+
+// Buffer entries emitted before the renderer subscribes (CLI runs during startup, before
+// the notification store mounts) and replay them to the first subscriber.
+const BUFFER_CAP = 500;
+const buffer: any[] = [];
+
+function emit(entry: any) {
+  if (!enabled) {
+    return;
+  }
+  if (subscribers.size === 0) {
+    buffer.push(entry);
+    if (buffer.length > BUFFER_CAP) {
+      buffer.shift();
+    }
+    return;
+  }
+  for (const callback of subscribers) {
+    try {
+      callback(entry);
+    } catch {
+      // A dead/throwing renderer subscriber must never break command execution.
+    }
+  }
+}
+
+export const ActivityBus = {
+  subscribe(callback: Subscriber) {
+    if (buffer.length > 0) {
+      for (const entry of buffer) {
+        try {
+          callback(entry);
+        } catch {
+          // ignore replay errors
+        }
+      }
+      buffer.length = 0;
+    }
+    subscribers.add(callback);
+    return () => {
+      subscribers.delete(callback);
+    };
+  },
+  setEnabled(value: boolean) {
+    enabled = value;
+  },
+};
+
+const MAX_PREVIEW = 4 * 1024;
+
+function preview(value: any): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const text = typeof value === "string" ? value : `${value}`;
+  if (!text) {
+    return undefined;
+  }
+  return text.length > MAX_PREVIEW ? `${text.slice(0, MAX_PREVIEW)}… (${text.length} bytes)` : text;
+}
+
+function toCommandLine(launcher: string, args?: readonly string[]): string {
+  return [launcher, ...(args || [])].map((part) => (/\s/.test(`${part}`) ? JSON.stringify(part) : `${part}`)).join(" ");
+}
+
+export function wrapCommandForActivity(command: ICommand): ICommand {
+  const wrapResult = (invocation: "Execute" | "Spawn") => {
+    const original = command[invocation].bind(command);
+    return async (launcher: string, args: string[], opts?: any) => {
+      const guid = crypto.randomUUID();
+      const startedAt = Date.now();
+      const commandLine = toCommandLine(launcher, args);
+      emit({ guid, date: startedAt, phase: "pending", invocation, launcher, args: args || [], commandLine });
+      try {
+        const result: any = await original(launcher, args, opts);
+        const exitCode = typeof result?.code === "number" ? result.code : (result?.status ?? null);
+        const success = typeof result?.success === "boolean" ? result.success : exitCode === 0;
+        emit({
+          guid,
+          date: Date.now(),
+          phase: "settled",
+          invocation,
+          launcher,
+          args: args || [],
+          commandLine,
+          status: success ? "ok" : "error",
+          exitCode,
+          durationMs: Date.now() - startedAt,
+          stdoutPreview: preview(result?.stdout),
+          stderrPreview: preview(result?.stderr),
+        });
+        return result;
+      } catch (error: any) {
+        emit({
+          guid,
+          date: Date.now(),
+          phase: "settled",
+          invocation,
+          launcher,
+          args: args || [],
+          commandLine,
+          status: "error",
+          durationMs: Date.now() - startedAt,
+          stderrPreview: preview(error?.message ?? error),
+        });
+        throw error;
+      }
+    };
+  };
+
+  const originalBackground = command.ExecuteAsBackgroundService.bind(command);
+  const wrappedBackground = async (launcher: string, args: string[], opts?: any) => {
+    const guid = crypto.randomUUID();
+    const startedAt = Date.now();
+    const commandLine = toCommandLine(launcher, args);
+    const base = {
+      guid,
+      invocation: "ExecuteAsBackgroundService" as const,
+      launcher,
+      args: args || [],
+      commandLine,
+      background: true,
+    };
+    emit({ ...base, date: startedAt, phase: "pending" });
+    const emitter: any = await originalBackground(launcher, args, opts);
+    try {
+      emitter?.on?.("ready", () =>
+        emit({ ...base, date: Date.now(), phase: "settled", status: "ok", durationMs: Date.now() - startedAt }),
+      );
+      emitter?.on?.("error", (error: any) =>
+        emit({
+          ...base,
+          date: Date.now(),
+          phase: "settled",
+          status: "error",
+          durationMs: Date.now() - startedAt,
+          stderrPreview: preview(error?.message ?? error),
+        }),
+      );
+    } catch {
+      // Some service emitters may not expose `on`; the pending entry still records the launch.
+    }
+    return emitter; // returned unwrapped to the caller — the EventEmitter never crosses the bus
+  };
+
+  return {
+    ...command,
+    Execute: wrapResult("Execute"),
+    Spawn: wrapResult("Spawn"),
+    ExecuteAsBackgroundService: wrappedBackground,
+  };
+}

--- a/src/electron-shell/preload.ts
+++ b/src/electron-shell/preload.ts
@@ -2,10 +2,15 @@ import { contextBridge } from "electron";
 
 import { CURRENT_OS_TYPE, FS, Path, Platform } from "@/platform/node";
 import { Command } from "@/platform/node-executor";
+import { ActivityBus, wrapCommandForActivity } from "./activityBus";
 import { MessageBus } from "./shared";
 
+// Wrap Command BEFORE exposing it so every renderer-initiated CLI call is captured for the
+// Activity Log. The wrapped instance is what both the global patch and the renderer see.
+const ActivityCommand = wrapCommandForActivity(Command);
+
 // patch global like in preload
-(global as any).Command = Command;
+(global as any).Command = ActivityCommand;
 (global as any).Platform = Platform;
 (global as any).Path = Path;
 (global as any).FS = FS;
@@ -14,12 +19,13 @@ import { MessageBus } from "./shared";
 
 function main() {
   console.debug("Preload script loaded");
-  contextBridge.exposeInMainWorld("Command", Command);
+  contextBridge.exposeInMainWorld("Command", ActivityCommand);
   contextBridge.exposeInMainWorld("Platform", Platform);
   contextBridge.exposeInMainWorld("Path", Path);
   contextBridge.exposeInMainWorld("FS", FS);
   contextBridge.exposeInMainWorld("CURRENT_OS_TYPE", CURRENT_OS_TYPE);
   contextBridge.exposeInMainWorld("MessageBus", MessageBus);
+  contextBridge.exposeInMainWorld("ActivityBus", ActivityBus);
   contextBridge.exposeInMainWorld("Preloaded", true);
 }
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -70,12 +70,20 @@ declare global {
     send: (channel: string, ...data: any[]) => void;
   }
 
+  // Preload-exposed CLI activity bridge (see electron-shell/activityBus.ts). subscribe()
+  // returns an unsubscribe fn and replays entries buffered before the first subscriber.
+  export interface IActivityBus {
+    subscribe: (callback: (entry: any) => void) => () => void;
+    setEnabled: (enabled: boolean) => void;
+  }
+
   var Platform: IPlatform;
   var Command: ICommand;
   var Path: IPath;
   var FS: IFileSystem;
   var CURRENT_OS_TYPE: OperatingSystem;
   var MessageBus: IMessageBus;
+  var ActivityBus: IActivityBus;
 
   interface Window {
     Platform: IPlatform;
@@ -84,6 +92,7 @@ declare global {
     FS: IFileSystem;
     CURRENT_OS_TYPE: any;
     MessageBus: IMessageBus;
+    ActivityBus: IActivityBus;
   }
 }
 

--- a/src/web-app/App.tsx
+++ b/src/web-app/App.tsx
@@ -25,6 +25,7 @@ import { AppHeader } from "@/web-app/components/AppHeader";
 import { AppLoading } from "@/web-app/components/AppLoading";
 import { AppSidebar } from "@/web-app/components/AppSidebar";
 import { FindHost } from "@/web-app/components/Find/FindHost";
+import { NotificationCenterHost } from "@/web-app/components/NotificationCenter/NotificationCenterHost";
 import { CURRENT_ENVIRONMENT } from "@/web-app/Environment";
 import { pathTo } from "@/web-app/Navigator";
 import { Screen as ContainerGenerateKubeScreen } from "@/web-app/screens/Container/GenerateKubeScreen";
@@ -206,6 +207,7 @@ function AppLayout() {
           <div className="AppContentDocument">
             {content}
             <FindHost />
+            <NotificationCenterHost />
           </div>
         </div>
       </AppErrorBoundary>

--- a/src/web-app/Notification.tsx
+++ b/src/web-app/Notification.tsx
@@ -1,5 +1,6 @@
 import { type Intent, OverlayToaster, Position } from "@blueprintjs/core";
 
+import { systemNotifier } from "@/container-client/notifier";
 import "./Notification.css";
 
 const Toaster = await OverlayToaster.create({
@@ -10,7 +11,9 @@ const Toaster = await OverlayToaster.create({
 
 export const Notification = {
   show: ({ message, intent = "success", timeout = 3000 }: { message: string; intent: Intent; timeout?: number }) => {
-    console.debug("Notification.show", { message, intent, timeout });
     Toaster.show({ message, intent, timeout });
+    // Tee every toast into the in-memory activity bus so the Notification Center keeps a
+    // history. The ~70 existing call sites are unchanged — this is the single emit point.
+    systemNotifier.transmit("activity.notification", { message, intent });
   },
 };

--- a/src/web-app/components/AppFooter.css
+++ b/src/web-app/components/AppFooter.css
@@ -7,10 +7,17 @@
 }
 .AppFooterNavbar {
   display: flex;
+  flex: 1 1 auto;
   margin: 0;
   padding: 0;
   box-shadow: none !important;
   height: 32px;
+  align-items: center;
+}
+/* Pin the bell to the far-right edge of the footer. */
+.AppFooterRightColumn {
+  margin-left: auto;
+  display: flex;
   align-items: center;
 }
 .AppFooter .bp6-navbar-group {

--- a/src/web-app/components/AppFooter.tsx
+++ b/src/web-app/components/AppFooter.tsx
@@ -1,5 +1,6 @@
-import { Navbar, NavbarDivider, NavbarHeading } from "@blueprintjs/core";
+import { Alignment, Navbar, NavbarDivider, NavbarGroup, NavbarHeading } from "@blueprintjs/core";
 import i18n from "@/web-app/App.i18n";
+import { FooterBell } from "@/web-app/components/NotificationCenter/FooterBell";
 import { useAppStore } from "@/web-app/stores/appStore";
 import "./AppFooter.css";
 
@@ -52,6 +53,9 @@ export const AppFooter = () => {
             </NavbarHeading>
           </>
         )}
+        <NavbarGroup align={Alignment.END} className="AppFooterRightColumn">
+          <FooterBell />
+        </NavbarGroup>
       </Navbar>
     </div>
   );

--- a/src/web-app/components/NotificationCenter/ActivityRow.tsx
+++ b/src/web-app/components/NotificationCenter/ActivityRow.tsx
@@ -1,0 +1,204 @@
+import { Button, Collapse, Icon, type Intent, Tag } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
+import { type ReactNode, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { ActivityEntry } from "@/web-app/stores/activityTypes";
+import { formatRelativeTime } from "./activityFilters";
+import { friendlyEndpoint } from "./endpointLabels";
+
+function primaryText(entry: ActivityEntry): string {
+  switch (entry.kind) {
+    case "api":
+      return friendlyEndpoint(entry.method, entry.url) ?? `${entry.method} ${entry.url}`;
+    case "cli":
+      return entry.commandLine;
+    case "notification":
+      return entry.message;
+    default:
+      return entry.title;
+  }
+}
+
+function secondaryText(entry: ActivityEntry): string | null {
+  switch (entry.kind) {
+    case "api":
+      return `${entry.method} ${entry.url}`;
+    case "cli":
+      return entry.invocation;
+    case "system":
+      return entry.eventType;
+    default:
+      return null;
+  }
+}
+
+function formatDuration(ms?: number): string | null {
+  if (typeof ms !== "number") {
+    return null;
+  }
+  return ms >= 1000 ? `${(ms / 1000).toFixed(ms >= 10000 ? 0 : 1)}s` : `${ms}ms`;
+}
+
+function isExpandable(entry: ActivityEntry): boolean {
+  if (entry.kind === "api" || entry.kind === "cli") {
+    return true;
+  }
+  return entry.kind === "system" && entry.data != null;
+}
+
+function safeJson(value: unknown): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function StatusBadge({ entry }: { entry: ActivityEntry }) {
+  if (entry.kind === "api") {
+    if (entry.status === "pending") {
+      return <Tag minimal>…</Tag>;
+    }
+    const intent: Intent = entry.severity === "error" ? "danger" : entry.severity === "warning" ? "warning" : "success";
+    return (
+      <Tag intent={intent} minimal>
+        {entry.httpStatus ?? (entry.status === "error" ? "ERR" : "—")}
+      </Tag>
+    );
+  }
+  if (entry.kind === "cli") {
+    if (entry.status === "pending") {
+      return <Tag minimal>…</Tag>;
+    }
+    return (
+      <Tag intent={entry.status === "error" ? "danger" : "success"} minimal>
+        exit {entry.exitCode ?? 0}
+      </Tag>
+    );
+  }
+  return null;
+}
+
+function DetailBlock({ label, value, action }: { label: string; value?: string; action?: ReactNode }) {
+  if (!value && !action) {
+    return null;
+  }
+  return (
+    <div className="ActivityDetailBlock">
+      <div className="ActivityDetailLabel">
+        <span>{label}</span>
+        {action}
+      </div>
+      {value ? <pre className="ActivityDetailPre">{value}</pre> : null}
+    </div>
+  );
+}
+
+export function ActivityRow({ entry, count = 1 }: { entry: ActivityEntry; count?: number }) {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+  const [copied, setCopied] = useState<string | null>(null);
+  const expandable = isExpandable(entry);
+  const secondary = secondaryText(entry);
+  const duration = formatDuration("durationMs" in entry ? entry.durationMs : undefined);
+
+  const copy = (text: string | undefined, key: string) => {
+    if (!text) {
+      return;
+    }
+    navigator.clipboard?.writeText(text).then(
+      () => {
+        setCopied(key);
+        window.setTimeout(() => setCopied(null), 1500);
+      },
+      () => undefined,
+    );
+  };
+
+  const copyIcon = (key: string) => (copied === key ? IconNames.TICK : IconNames.DUPLICATE);
+
+  // Icon-only copy button rendered inline on a DetailBlock's label line (saves the vertical
+  // space of a standalone action row); the action text lives in the tooltip.
+  const copyAction = (key: string, text: string | undefined): ReactNode =>
+    text ? (
+      <Button
+        className="ActivityCopyButton"
+        variant="minimal"
+        size="small"
+        icon={copyIcon(key)}
+        title={copied === key ? t("Copied") : t("Copy")}
+        aria-label={t("Copy")}
+        onClick={() => copy(text, key)}
+      />
+    ) : undefined;
+
+  const headerInner = (
+    <>
+      <span className="ActivityRowDot" data-severity={entry.severity} />
+      <span className="ActivityRowMain">
+        <span className="ActivityRowPrimary">
+          {primaryText(entry)}
+          {count > 1 ? (
+            <Tag round minimal className="ActivityRowCount">
+              ×{count}
+            </Tag>
+          ) : null}
+        </span>
+        {secondary ? <span className="ActivityRowSecondary">{secondary}</span> : null}
+      </span>
+      <span className="ActivityRowMeta">
+        <StatusBadge entry={entry} />
+        {duration ? (
+          <Tag minimal className="ActivityRowDuration">
+            {duration}
+          </Tag>
+        ) : null}
+        <span className="ActivityRowTime" title={new Date(entry.date).toLocaleString()}>
+          {formatRelativeTime(entry.date)}
+        </span>
+        {expandable ? <Icon icon={expanded ? IconNames.CHEVRON_UP : IconNames.CHEVRON_DOWN} size={12} /> : null}
+      </span>
+    </>
+  );
+
+  return (
+    <div className="ActivityRow" data-kind={entry.kind} data-severity={entry.severity} data-expandable={expandable}>
+      {expandable ? (
+        <button
+          type="button"
+          className="ActivityRowHeader"
+          aria-expanded={expanded}
+          onClick={() => setExpanded((value) => !value)}
+        >
+          {headerInner}
+        </button>
+      ) : (
+        <div className="ActivityRowHeader">{headerInner}</div>
+      )}
+      {expandable ? (
+        <Collapse isOpen={expanded}>
+          <div className="ActivityRowDetail">
+            {entry.kind === "api" ? (
+              <>
+                <DetailBlock label={t("Equivalent cURL")} value={entry.curl} action={copyAction("curl", entry.curl)} />
+                <DetailBlock label={t("Request body")} value={entry.requestBody} />
+                {entry.error ? <DetailBlock label={t("Error")} value={entry.error} /> : null}
+              </>
+            ) : null}
+            {entry.kind === "cli" ? (
+              <>
+                <DetailBlock label="stdout" value={entry.stdoutPreview} action={copyAction("cmd", entry.commandLine)} />
+                <DetailBlock label="stderr" value={entry.stderrPreview} />
+              </>
+            ) : null}
+            {entry.kind === "system" ? <DetailBlock label={entry.eventType} value={safeJson(entry.data)} /> : null}
+          </div>
+        </Collapse>
+      ) : null}
+    </div>
+  );
+}

--- a/src/web-app/components/NotificationCenter/ActivityTab.tsx
+++ b/src/web-app/components/NotificationCenter/ActivityTab.tsx
@@ -1,0 +1,41 @@
+import { NonIdealState } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
+import { useTranslation } from "react-i18next";
+
+import { useActivityStore } from "@/web-app/stores/activityStore";
+import { ACTIVITY_TAB_KINDS } from "@/web-app/stores/activityTypes";
+import { ActivityRow } from "./ActivityRow";
+import { ActivityToolbar } from "./ActivityToolbar";
+import { collapseConsecutiveDuplicates, filterEntries } from "./activityFilters";
+
+export function ActivityTab() {
+  const { t } = useTranslation();
+  const entries = useActivityStore((state) => state.entries);
+  const search = useActivityStore((state) => state.search.activity);
+  const filters = useActivityStore((state) => state.filters.activity);
+
+  const list = filterEntries(entries, {
+    tabKinds: ACTIVITY_TAB_KINDS,
+    kinds: filters.kinds,
+    severities: filters.severities,
+    search,
+  });
+  const rows = collapseConsecutiveDuplicates(list);
+
+  return (
+    <div className="NotificationCenterPanel" data-tab="activity">
+      <ActivityToolbar tab="activity" showKinds />
+      <div className="ActivityListScroll">
+        {rows.length === 0 ? (
+          <NonIdealState icon={IconNames.HISTORY} title={t("No activity recorded yet")} />
+        ) : (
+          <div className="ActivityList">
+            {rows.map(({ entry, count }) => (
+              <ActivityRow key={entry.guid} entry={entry} count={count} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/web-app/components/NotificationCenter/ActivityToolbar.tsx
+++ b/src/web-app/components/NotificationCenter/ActivityToolbar.tsx
@@ -1,0 +1,88 @@
+import { type ActionProps, Button, ButtonGroup, InputGroup, type Intent } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
+import { useTranslation } from "react-i18next";
+
+import { type ActivityTab, useActivityStore } from "@/web-app/stores/activityStore";
+import {
+  ACTIVITY_SEVERITIES,
+  ACTIVITY_TAB_KINDS,
+  type ActivityKind,
+  type ActivitySeverity,
+} from "@/web-app/stores/activityTypes";
+
+const SEVERITY_ICON: Record<ActivitySeverity, ActionProps["icon"]> = {
+  info: IconNames.INFO_SIGN,
+  success: IconNames.TICK_CIRCLE,
+  warning: IconNames.WARNING_SIGN,
+  error: IconNames.ERROR,
+};
+const SEVERITY_INTENT: Record<ActivitySeverity, Intent> = {
+  info: "primary",
+  success: "success",
+  warning: "warning",
+  error: "danger",
+};
+const KIND_LABEL: Record<ActivityKind, string> = {
+  notification: "Notifications",
+  api: "API",
+  cli: "CLI",
+  system: "System",
+};
+
+// A single compact filter bar: the search field carries the kind + severity toggles as its
+// right element. Pause/Clear actions live in the drawer header (see NotificationCenterHost).
+export function ActivityToolbar({ tab, showKinds = false }: { tab: ActivityTab; showKinds?: boolean }) {
+  const { t } = useTranslation();
+  const search = useActivityStore((state) => state.search[tab]);
+  const setSearch = useActivityStore((state) => state.setSearch);
+  const filters = useActivityStore((state) => state.filters[tab]);
+  const toggleKind = useActivityStore((state) => state.toggleKind);
+  const toggleSeverity = useActivityStore((state) => state.toggleSeverity);
+
+  const filterControls = (
+    <div className="ActivityToolbarFilters">
+      {showKinds ? (
+        <ButtonGroup>
+          {ACTIVITY_TAB_KINDS.map((kind) => (
+            <Button
+              key={kind}
+              size="small"
+              variant={filters.kinds.includes(kind) ? "solid" : "minimal"}
+              text={t(KIND_LABEL[kind])}
+              onClick={() => toggleKind(tab, kind)}
+            />
+          ))}
+        </ButtonGroup>
+      ) : null}
+      <ButtonGroup>
+        {ACTIVITY_SEVERITIES.map((severity) => (
+          <Button
+            key={severity}
+            size="small"
+            variant={filters.severities.includes(severity) ? "solid" : "minimal"}
+            icon={SEVERITY_ICON[severity]}
+            intent={SEVERITY_INTENT[severity]}
+            title={t(severity)}
+            aria-label={severity}
+            onClick={() => toggleSeverity(tab, severity)}
+          />
+        ))}
+      </ButtonGroup>
+    </div>
+  );
+
+  return (
+    <div className="ActivityToolbar">
+      <InputGroup
+        className="ActivityToolbarSearch"
+        size="small"
+        fill
+        leftIcon={IconNames.SEARCH}
+        placeholder={t("Filter…")}
+        value={search}
+        onChange={(event) => setSearch(tab, event.target.value)}
+        rightElement={filterControls}
+      />
+    </div>
+  );
+}

--- a/src/web-app/components/NotificationCenter/FooterBell.tsx
+++ b/src/web-app/components/NotificationCenter/FooterBell.tsx
@@ -1,0 +1,31 @@
+import { Button, Tag } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
+import { useTranslation } from "react-i18next";
+
+import { selectUnreadCount, useActivityStore } from "@/web-app/stores/activityStore";
+
+// Lives in the per-screen footer; only toggles store state (the drawer itself is mounted
+// once in NotificationCenterHost). Shows an unread badge for entries since last opened.
+export function FooterBell() {
+  const { t } = useTranslation();
+  const toggleDrawer = useActivityStore((state) => state.toggleDrawer);
+  const unread = useActivityStore(selectUnreadCount);
+
+  return (
+    <div className="FooterBell">
+      <Button
+        variant="minimal"
+        size="small"
+        icon={IconNames.NOTIFICATIONS}
+        onClick={toggleDrawer}
+        title={t("Notifications & activity")}
+        aria-label={t("Notifications & activity")}
+      />
+      {unread > 0 ? (
+        <Tag className="FooterBellBadge" round intent="danger">
+          {unread > 99 ? "99+" : unread}
+        </Tag>
+      ) : null}
+    </div>
+  );
+}

--- a/src/web-app/components/NotificationCenter/NotificationCenter.css
+++ b/src/web-app/components/NotificationCenter/NotificationCenter.css
@@ -1,0 +1,228 @@
+/* Structure only — engine/theme colors are layered on in themes/podman.css + docker.css.
+   The drawer background itself is already supplied by the shared .AppDrawer rules. */
+
+.NotificationCenterDrawer .bp6-drawer-body {
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+/* Drawer header bar: tab switcher on the left, Pause/Clear actions right after it. */
+.NotificationCenterHeaderBar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  font-weight: normal;
+}
+/* Spacer pushes Pause/Clear to the far right, next to the drawer close icon. */
+.NotificationCenterHeaderActions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+/* Segmented switcher = Blueprint ButtonGroup; the framework renders the active state.
+   The active button is tinted per engine in themes/podman.css + docker.css. */
+.NotificationCenterSwitch .NotificationCenterSwitchCount {
+  margin-left: 6px;
+  font-size: 10px;
+}
+
+.NotificationCenterSwitch .bp6-button-text {
+  vertical-align: middle;
+}
+
+/* The drawer body's only child is the active tab panel — let it fill and self-scroll. */
+.NotificationCenterDrawer .bp6-drawer-body > .NotificationCenterPanel {
+  flex: 1 1 auto;
+}
+.NotificationCenterPanel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+.ActivityListScroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 4px 0 12px;
+}
+
+/* Filter toolbar: a single search field carrying the kind/severity toggles as its
+   right element. */
+.ActivityToolbar {
+  flex: 0 0 auto;
+  padding: 8px 12px;
+  border-bottom: 1px solid rgba(138, 155, 168, 0.15);
+}
+.ActivityToolbarFilters {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.ActivityList {
+  display: flex;
+  flex-direction: column;
+}
+
+.ActivityRow {
+  border-bottom: 1px solid rgba(138, 155, 168, 0.15);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+/* Header is a reset <button> when expandable, a plain <div> otherwise. */
+.ActivityRowHeader {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  width: 100%;
+  margin: 0;
+  padding: 8px 14px;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+}
+button.ActivityRowHeader {
+  cursor: pointer;
+}
+button.ActivityRowHeader:hover {
+  background: rgba(138, 155, 168, 0.08);
+}
+
+.ActivityRowDot {
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  margin-top: 4px;
+  border-radius: 50%;
+  background: #8a9ba8;
+}
+.ActivityRowDot[data-severity="info"] {
+  background: #6caaff;
+}
+.ActivityRowDot[data-severity="success"] {
+  background: #3dcc91;
+}
+.ActivityRowDot[data-severity="warning"] {
+  background: #ffb366;
+}
+.ActivityRowDot[data-severity="error"] {
+  background: #ff7373;
+}
+
+.ActivityRowMain {
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  flex-direction: column;
+}
+.ActivityRowPrimary {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 500;
+  word-break: break-word;
+}
+.ActivityRowSecondary {
+  margin-top: 2px;
+  font-family: var(--monospace-font, monospace);
+  font-size: 11px;
+  opacity: 0.6;
+  word-break: break-all;
+}
+.ActivityRowMeta {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 4px;
+  margin-top: 1px;
+  white-space: nowrap;
+}
+.ActivityRowMeta .bp6-tag {
+  min-height: 16px;
+  padding: 0 5px;
+  font-size: 10px;
+}
+.ActivityRowTime {
+  font-size: 11px;
+  opacity: 0.5;
+}
+.ActivityRowCount {
+  font-size: 10px;
+}
+
+/* Expanded detail (request/response, stdout/stderr, copy actions) */
+.ActivityRowDetail {
+  display: flex;
+  flex-direction: column;
+  padding: 4px;
+}
+/* Label line carries an optional inline action (e.g. Copy as cURL) on the right, so it
+   doesn't cost an extra row. */
+.ActivityDetailLabel {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-height: 20px;
+  margin-bottom: 2px;
+}
+.ActivityDetailLabel > span {
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0.55;
+}
+.ActivityCopyButton.bp6-button {
+  min-height: 20px;
+  padding: 0 6px;
+}
+.ActivityDetailPre {
+  margin: 0;
+  max-height: 220px;
+  padding: 6px 8px;
+  overflow: auto;
+  font-family: var(--monospace-font, monospace);
+  font-size: 11px;
+  white-space: pre-wrap;
+  word-break: break-all;
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: 3px;
+}
+
+/* Footer bell + unread badge */
+.FooterBell {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+.FooterBell .FooterBellBadge {
+  position: absolute;
+  top: -2px;
+  right: -4px;
+  min-width: 16px;
+  min-height: 16px;
+  padding: 0 4px;
+  font-size: 9px;
+  line-height: 16px;
+  text-align: center;
+  pointer-events: none;
+}
+
+/* Light-theme readability: the code/detail panes and hover need a light wash on the white
+   drawer (the dark default is for dark mode). Engine accents live in themes/{podman,docker}.css. */
+body.bp6-light .NotificationCenterDrawer .ActivityDetailPre {
+  background: rgba(17, 20, 24, 0.07);
+  color: #1c2127;
+}
+body.bp6-light .NotificationCenterDrawer button.ActivityRowHeader:hover {
+  background: rgba(17, 20, 24, 0.05);
+}

--- a/src/web-app/components/NotificationCenter/NotificationCenterHost.tsx
+++ b/src/web-app/components/NotificationCenter/NotificationCenterHost.tsx
@@ -1,0 +1,98 @@
+import { Button, ButtonGroup, Classes, Drawer, DrawerSize, Position, Tag } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+
+import { ensureCliBusSubscribed, type ActivityTab as TabId, useActivityStore } from "@/web-app/stores/activityStore";
+import { ActivityTab } from "./ActivityTab";
+import { NotificationsTab } from "./NotificationsTab";
+import "./NotificationCenter.css";
+
+// Single, app-wide mount for the notification center drawer (mirrors FindHost). The
+// per-screen footer bell only toggles store state; the drawer + entries live here so
+// they persist across navigation.
+//
+// A custom segmented switcher lives in the drawer header bar (as the title) — it reads
+// better than the framework tabs and shows a per-tab count. The body renders only the
+// active tab's content.
+export function NotificationCenterHost() {
+  const { t } = useTranslation();
+  const isOpen = useActivityStore((state) => state.drawerOpen);
+  const activeTab = useActivityStore((state) => state.activeTab);
+  const setActiveTab = useActivityStore((state) => state.setActiveTab);
+  const closeDrawer = useActivityStore((state) => state.closeDrawer);
+  const paused = useActivityStore((state) => state.paused);
+  const togglePause = useActivityStore((state) => state.togglePause);
+  const clear = useActivityStore((state) => state.clear);
+  const notificationCount = useActivityStore((state) =>
+    state.entries.reduce((total, entry) => (entry.kind === "notification" ? total + 1 : total), 0),
+  );
+  const activityCount = useActivityStore((state) =>
+    state.entries.reduce((total, entry) => (entry.kind === "notification" ? total : total + 1), 0),
+  );
+
+  // Subscribe to the preload CLI bridge once the bridge is available (covers the case where
+  // the store module evaluated before window.ActivityBus was exposed).
+  useEffect(() => {
+    ensureCliBusSubscribed();
+  }, []);
+
+  const tabs: { id: TabId; label: string; count: number }[] = [
+    { id: "notifications", label: t("Notifications"), count: notificationCount },
+    { id: "activity", label: t("Activity"), count: activityCount },
+  ];
+
+  return (
+    <Drawer
+      className="AppDrawer NotificationCenterDrawer"
+      position={Position.RIGHT}
+      size={DrawerSize.SMALL}
+      hasBackdrop={false}
+      usePortal
+      isOpen={isOpen}
+      onClose={closeDrawer}
+      icon={IconNames.NOTIFICATIONS}
+      title={
+        <div className="NotificationCenterHeaderBar">
+          <ButtonGroup className="NotificationCenterSwitch">
+            {tabs.map((tab) => (
+              <Button key={tab.id} active={activeTab === tab.id} onClick={() => setActiveTab(tab.id)}>
+                {tab.label}
+                {tab.count > 0 ? (
+                  <Tag round minimal className="NotificationCenterSwitchCount">
+                    {tab.count > 99 ? "99+" : tab.count}
+                  </Tag>
+                ) : null}
+              </Button>
+            ))}
+          </ButtonGroup>
+          <div className="NotificationCenterHeaderActions">
+            {activeTab === "activity" ? (
+              <Button
+                variant={paused ? "solid" : "minimal"}
+                size="small"
+                intent={paused ? "warning" : "none"}
+                icon={paused ? IconNames.PLAY : IconNames.PAUSE}
+                title={paused ? t("Resume recording") : t("Pause recording")}
+                aria-label="toggle-pause"
+                onClick={togglePause}
+              />
+            ) : null}
+            <Button
+              variant="minimal"
+              size="small"
+              icon={IconNames.TRASH}
+              title={t("Clear")}
+              aria-label="clear-activity"
+              onClick={() => clear(activeTab)}
+            />
+          </div>
+        </div>
+      }
+    >
+      <div className={Classes.DRAWER_BODY}>
+        {activeTab === "notifications" ? <NotificationsTab /> : <ActivityTab />}
+      </div>
+    </Drawer>
+  );
+}

--- a/src/web-app/components/NotificationCenter/NotificationsTab.tsx
+++ b/src/web-app/components/NotificationCenter/NotificationsTab.tsx
@@ -1,0 +1,41 @@
+import { NonIdealState } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
+import { useTranslation } from "react-i18next";
+
+import { useActivityStore } from "@/web-app/stores/activityStore";
+import { ActivityRow } from "./ActivityRow";
+import { ActivityToolbar } from "./ActivityToolbar";
+import { filterEntries } from "./activityFilters";
+
+const TAB_KINDS = ["notification"] as const;
+
+export function NotificationsTab() {
+  const { t } = useTranslation();
+  const entries = useActivityStore((state) => state.entries);
+  const search = useActivityStore((state) => state.search.notifications);
+  const filters = useActivityStore((state) => state.filters.notifications);
+
+  const list = filterEntries(entries, {
+    tabKinds: [...TAB_KINDS],
+    kinds: filters.kinds,
+    severities: filters.severities,
+    search,
+  });
+
+  return (
+    <div className="NotificationCenterPanel" data-tab="notifications">
+      <ActivityToolbar tab="notifications" />
+      <div className="ActivityListScroll">
+        {list.length === 0 ? (
+          <NonIdealState icon={IconNames.NOTIFICATIONS} title={t("No notifications yet")} />
+        ) : (
+          <div className="ActivityList">
+            {list.map((entry) => (
+              <ActivityRow key={entry.guid} entry={entry} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/web-app/components/NotificationCenter/activityFilters.test.ts
+++ b/src/web-app/components/NotificationCenter/activityFilters.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import type { ActivityEntry, ApiEntry, SystemEntry } from "@/web-app/stores/activityTypes";
+import { collapseConsecutiveDuplicates, filterEntries, formatRelativeTime } from "./activityFilters";
+
+let seq = 0;
+function apiEntry(over: Partial<ApiEntry> = {}): ActivityEntry {
+  seq += 1;
+  return {
+    guid: `g${seq}`,
+    date: 1000,
+    kind: "api",
+    severity: "success",
+    title: "api",
+    method: "GET",
+    url: "/containers/json",
+    label: "List containers",
+    status: "ok",
+    httpStatus: 200,
+    ...over,
+  } as ApiEntry;
+}
+function systemEntry(over: Partial<SystemEntry> = {}): ActivityEntry {
+  seq += 1;
+  return {
+    guid: `g${seq}`,
+    date: 1000,
+    kind: "system",
+    severity: "info",
+    title: "Startup finished",
+    eventType: "startup.phase",
+    ...over,
+  } as SystemEntry;
+}
+
+describe("filterEntries", () => {
+  it("restricts to the tab's allowed kinds", () => {
+    const entries = [apiEntry(), systemEntry()];
+    const out = filterEntries(entries, { tabKinds: ["notification"], kinds: [], severities: [], search: "" });
+    expect(out).toHaveLength(0);
+  });
+
+  it("applies kind chip filters within the tab", () => {
+    const entries = [apiEntry(), systemEntry()];
+    const out = filterEntries(entries, {
+      tabKinds: ["api", "cli", "system"],
+      kinds: ["system"],
+      severities: [],
+      search: "",
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0].kind).toBe("system");
+  });
+
+  it("applies severity filters", () => {
+    const entries = [apiEntry({ severity: "success" }), apiEntry({ severity: "error" })];
+    const out = filterEntries(entries, { tabKinds: ["api"], kinds: [], severities: ["error"], search: "" });
+    expect(out).toHaveLength(1);
+    expect(out[0].severity).toBe("error");
+  });
+
+  it("matches search against raw path and friendly label", () => {
+    const entries = [apiEntry({ url: "/images/json", label: "List images" })];
+    expect(
+      filterEntries(entries, { tabKinds: ["api"], kinds: [], severities: [], search: "images/json" }),
+    ).toHaveLength(1);
+    expect(
+      filterEntries(entries, { tabKinds: ["api"], kinds: [], severities: [], search: "list images" }),
+    ).toHaveLength(1);
+    expect(filterEntries(entries, { tabKinds: ["api"], kinds: [], severities: [], search: "nope" })).toHaveLength(0);
+  });
+});
+
+describe("collapseConsecutiveDuplicates", () => {
+  it("folds adjacent identical entries into a counted run", () => {
+    const entries = [
+      apiEntry({ url: "/x", httpStatus: 200 }),
+      apiEntry({ url: "/x", httpStatus: 200 }),
+      apiEntry({ url: "/y", httpStatus: 200 }),
+    ];
+    const out = collapseConsecutiveDuplicates(entries);
+    expect(out).toHaveLength(2);
+    expect(out[0].count).toBe(2);
+    expect(out[1].count).toBe(1);
+  });
+
+  it("does not merge non-adjacent duplicates", () => {
+    const entries = [apiEntry({ url: "/x" }), apiEntry({ url: "/y" }), apiEntry({ url: "/x" })];
+    const out = collapseConsecutiveDuplicates(entries);
+    expect(out).toHaveLength(3);
+  });
+});
+
+describe("formatRelativeTime", () => {
+  const now = 10_000_000;
+  it("formats recent, minute, hour and day buckets", () => {
+    expect(formatRelativeTime(now, now)).toBe("now");
+    expect(formatRelativeTime(now - 3_000, now)).toBe("now");
+    expect(formatRelativeTime(now - 10_000, now)).toBe("10s");
+    expect(formatRelativeTime(now - 120_000, now)).toBe("2m");
+    expect(formatRelativeTime(now - 3 * 3_600_000, now)).toBe("3h");
+    expect(formatRelativeTime(now - 2 * 86_400_000, now)).toBe("2d");
+  });
+});

--- a/src/web-app/components/NotificationCenter/activityFilters.ts
+++ b/src/web-app/components/NotificationCenter/activityFilters.ts
@@ -1,0 +1,103 @@
+// Pure helpers for the Notification Center — no React, no store imports, so they are
+// trivially unit-testable. Entries arrive newest-first from the store, so filtering
+// preserves order (no re-sort needed).
+
+import type { ActivityEntry, ActivityKind, ActivitySeverity } from "@/web-app/stores/activityTypes";
+import { friendlyEndpoint } from "./endpointLabels";
+
+export interface FilterOptions {
+  tabKinds: ActivityKind[]; // the kinds this tab is allowed to show
+  kinds: ActivityKind[]; // chip filter within the tab (empty = all tabKinds)
+  severities: ActivitySeverity[]; // empty = all severities
+  search: string;
+}
+
+// Free-text haystack per entry kind (lowercased by the caller). API entries also match on
+// their friendly label ("list containers") so search works on human terms.
+export function entryHaystack(entry: ActivityEntry): string {
+  switch (entry.kind) {
+    case "api":
+      return `${entry.method} ${entry.url} ${friendlyEndpoint(entry.method, entry.url) ?? ""}`;
+    case "cli":
+      return `${entry.commandLine} ${entry.title}`;
+    case "notification":
+      return entry.message;
+    default:
+      return `${entry.eventType} ${entry.title}`;
+  }
+}
+
+export function filterEntries(entries: ActivityEntry[], opts: FilterOptions): ActivityEntry[] {
+  const query = opts.search.trim().toLowerCase();
+  return entries.filter((entry) => {
+    if (!opts.tabKinds.includes(entry.kind)) {
+      return false;
+    }
+    if (opts.kinds.length > 0 && !opts.kinds.includes(entry.kind)) {
+      return false;
+    }
+    if (opts.severities.length > 0 && !opts.severities.includes(entry.severity)) {
+      return false;
+    }
+    if (query.length > 0 && !entryHaystack(entry).toLowerCase().includes(query)) {
+      return false;
+    }
+    return true;
+  });
+}
+
+// Compact relative timestamp: "now", "12s", "5m", "3h", "2d".
+export function formatRelativeTime(ts: number, now: number = Date.now()): string {
+  const seconds = Math.floor(Math.max(0, now - ts) / 1000);
+  if (seconds < 5) {
+    return "now";
+  }
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${hours}h`;
+  }
+  return `${Math.floor(hours / 24)}d`;
+}
+
+export interface CollapsedEntry {
+  entry: ActivityEntry; // representative (the most recent of the run, since newest-first)
+  count: number;
+}
+
+function isSameRepeat(a: ActivityEntry, b: ActivityEntry): boolean {
+  if (a.kind !== b.kind) {
+    return false;
+  }
+  if (a.kind === "api" && b.kind === "api") {
+    return a.method === b.method && a.url === b.url && a.httpStatus === b.httpStatus;
+  }
+  if (a.kind === "cli" && b.kind === "cli") {
+    return a.commandLine === b.commandLine && a.exitCode === b.exitCode;
+  }
+  if (a.kind === "system" && b.kind === "system") {
+    return a.title === b.title;
+  }
+  return false;
+}
+
+// Fold runs of adjacent identical entries (e.g. repeated polls) into one row with a count,
+// so the activity stream stays readable. Operates on the already newest-first list.
+export function collapseConsecutiveDuplicates(entries: ActivityEntry[]): CollapsedEntry[] {
+  const out: CollapsedEntry[] = [];
+  for (const entry of entries) {
+    const last = out[out.length - 1];
+    if (last && isSameRepeat(last.entry, entry)) {
+      last.count += 1;
+    } else {
+      out.push({ entry, count: 1 });
+    }
+  }
+  return out;
+}

--- a/src/web-app/components/NotificationCenter/endpointLabels.test.ts
+++ b/src/web-app/components/NotificationCenter/endpointLabels.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { friendlyEndpoint } from "./endpointLabels";
+
+describe("friendlyEndpoint", () => {
+  it("labels common list/read routes (ignoring query strings)", () => {
+    expect(friendlyEndpoint("GET", "/containers/json?all=true")).toBe("List containers");
+    expect(friendlyEndpoint("GET", "/images/json")).toBe("List images");
+    expect(friendlyEndpoint("GET", "/networks")).toBe("List networks");
+    expect(friendlyEndpoint("GET", "/volumes")).toBe("List volumes");
+    expect(friendlyEndpoint("GET", "/_ping")).toBe("Ping engine");
+    expect(friendlyEndpoint("GET", "/version")).toBe("Engine version");
+  });
+
+  it("labels lifecycle routes", () => {
+    expect(friendlyEndpoint("POST", "/containers/create")).toBe("Create container");
+    expect(friendlyEndpoint("POST", "/containers/abc123/start")).toBe("Start container");
+    expect(friendlyEndpoint("POST", "/images/create?fromImage=nginx")).toBe("Pull image");
+  });
+
+  it("disambiguates by HTTP method on the same path shape", () => {
+    expect(friendlyEndpoint("GET", "/containers/abc123/json")).toBe("Inspect container");
+    expect(friendlyEndpoint("DELETE", "/containers/abc123")).toBe("Remove container");
+  });
+
+  it("returns undefined for unknown routes", () => {
+    expect(friendlyEndpoint("GET", "/totally/unknown/path")).toBeUndefined();
+  });
+});

--- a/src/web-app/components/NotificationCenter/endpointLabels.ts
+++ b/src/web-app/components/NotificationCenter/endpointLabels.ts
@@ -1,0 +1,74 @@
+// Map common Docker/Podman engine REST routes to human-friendly labels, so the Activity
+// log reads as documentation ("List containers") next to the raw call ("GET /containers/json").
+// Pure + order-sensitive (specific patterns before generic ones); unit-tested.
+
+interface EndpointRule {
+  re: RegExp;
+  methods?: string[];
+  label: string;
+}
+
+const RULES: EndpointRule[] = [
+  { re: /_ping$/, label: "Ping engine" },
+  { re: /\/version$/, label: "Engine version" },
+  { re: /\/info$/, label: "Engine info" },
+  { re: /\/events\b/, label: "Stream events" },
+  { re: /\/system\/df/, label: "Disk usage" },
+  // containers
+  { re: /\/containers\/create/, methods: ["POST"], label: "Create container" },
+  { re: /\/containers\/prune/, label: "Prune containers" },
+  { re: /\/containers\/json/, label: "List containers" },
+  { re: /\/containers\/[^/]+\/start/, label: "Start container" },
+  { re: /\/containers\/[^/]+\/stop/, label: "Stop container" },
+  { re: /\/containers\/[^/]+\/restart/, label: "Restart container" },
+  { re: /\/containers\/[^/]+\/kill/, label: "Kill container" },
+  { re: /\/containers\/[^/]+\/pause/, label: "Pause container" },
+  { re: /\/containers\/[^/]+\/unpause/, label: "Unpause container" },
+  { re: /\/containers\/[^/]+\/logs/, label: "Container logs" },
+  { re: /\/containers\/[^/]+\/stats/, label: "Container stats" },
+  { re: /\/containers\/[^/]+\/top/, label: "Container processes" },
+  { re: /\/containers\/[^/]+\/exec/, label: "Exec in container" },
+  { re: /\/containers\/[^/]+\/json/, label: "Inspect container" },
+  { re: /\/containers\/[^/]+$/, methods: ["DELETE"], label: "Remove container" },
+  // images
+  { re: /\/images\/create/, label: "Pull image" },
+  { re: /\/images\/prune/, label: "Prune images" },
+  { re: /\/images\/search/, label: "Search images" },
+  { re: /\/images\/json/, label: "List images" },
+  { re: /\/images\/[^/]+\/history/, label: "Image history" },
+  { re: /\/images\/[^/]+\/push/, label: "Push image" },
+  { re: /\/images\/[^/]+\/tag/, label: "Tag image" },
+  { re: /\/images\/[^/]+\/json/, label: "Inspect image" },
+  { re: /\/images\/[^/]+$/, methods: ["DELETE"], label: "Remove image" },
+  { re: /\/build\b/, label: "Build image" },
+  // networks
+  { re: /\/networks\/create/, label: "Create network" },
+  { re: /\/networks\/[^/]+$/, methods: ["DELETE"], label: "Remove network" },
+  { re: /\/networks\/[^/]+/, label: "Inspect network" },
+  { re: /\/networks/, label: "List networks" },
+  // volumes
+  { re: /\/volumes\/create/, label: "Create volume" },
+  { re: /\/volumes\/[^/]+$/, methods: ["DELETE"], label: "Remove volume" },
+  { re: /\/volumes\/[^/]+/, label: "Inspect volume" },
+  { re: /\/volumes/, label: "List volumes" },
+  // secrets / pods (podman) / misc
+  { re: /\/secrets\/create/, label: "Create secret" },
+  { re: /\/secrets/, label: "List secrets" },
+  { re: /\/pods\/json/, label: "List pods" },
+  { re: /\/pods\//, label: "Pod operation" },
+  { re: /\/exec\/[^/]+\/start/, label: "Start exec" },
+];
+
+export function friendlyEndpoint(method: string, url: string): string | undefined {
+  const path = `${url || ""}`.split("?")[0];
+  const upper = `${method || ""}`.toUpperCase();
+  for (const rule of RULES) {
+    if (rule.methods && !rule.methods.includes(upper)) {
+      continue;
+    }
+    if (rule.re.test(path)) {
+      return rule.label;
+    }
+  }
+  return undefined;
+}

--- a/src/web-app/stores/activityStore.ts
+++ b/src/web-app/stores/activityStore.ts
@@ -1,0 +1,287 @@
+import { create } from "zustand";
+
+import { systemNotifier } from "@/container-client/notifier";
+import type { SystemNotification } from "@/env/Types";
+import type {
+  ActivityEntry,
+  ActivityKind,
+  ActivitySeverity,
+  ActivityStatus,
+  ApiEntry,
+  CliBusPayload,
+  CliEntry,
+  NotificationEntry,
+  SystemEntry,
+} from "./activityTypes";
+
+// Hard ceiling on retained entries — the stream is in-memory only and never persisted.
+const CAP = 500;
+
+export type ActivityTab = "notifications" | "activity";
+
+export interface ActivityFilters {
+  kinds: ActivityKind[]; // empty = all kinds
+  severities: ActivitySeverity[]; // empty = all severities
+}
+
+interface ActivityState {
+  entries: ActivityEntry[]; // newest-first
+  lastSeenAt: number; // epoch ms of last drawer open — drives the unread badge
+  drawerOpen: boolean;
+  activeTab: ActivityTab;
+  paused: boolean; // when true, api/cli entries are dropped (notifications/system still recorded)
+  search: Record<ActivityTab, string>;
+  filters: Record<ActivityTab, ActivityFilters>;
+
+  // ingestion
+  ingest: (entry: ActivityEntry) => void;
+  upsert: (guid: string, patch: Partial<ActivityEntry>) => void;
+  // controls
+  clear: (tab?: ActivityTab) => void;
+  togglePause: () => void;
+  openDrawer: (tab?: ActivityTab) => void;
+  closeDrawer: () => void;
+  toggleDrawer: () => void;
+  markSeen: () => void;
+  setActiveTab: (tab: ActivityTab) => void;
+  setSearch: (tab: ActivityTab, term: string) => void;
+  toggleKind: (tab: ActivityTab, kind: ActivityKind) => void;
+  toggleSeverity: (tab: ActivityTab, severity: ActivitySeverity) => void;
+}
+
+export const useActivityStore = create<ActivityState>((set, get) => ({
+  entries: [],
+  lastSeenAt: 0,
+  drawerOpen: false,
+  activeTab: "notifications",
+  paused: false,
+  search: { notifications: "", activity: "" },
+  filters: {
+    notifications: { kinds: [], severities: [] },
+    activity: { kinds: [], severities: [] },
+  },
+
+  ingest: (entry) => {
+    if (get().paused && (entry.kind === "api" || entry.kind === "cli")) {
+      return;
+    }
+    set((state) => ({ entries: [entry, ...state.entries].slice(0, CAP) }));
+  },
+
+  upsert: (guid, patch) =>
+    set((state) => {
+      let found = false;
+      const entries = state.entries.map((e) => {
+        if (e.guid !== guid) {
+          return e;
+        }
+        found = true;
+        return { ...e, ...patch } as ActivityEntry;
+      });
+      return found ? { entries } : {};
+    }),
+
+  clear: (tab) =>
+    set((state) => {
+      if (!tab) {
+        return { entries: [] };
+      }
+      // "notifications" tab clears notification entries; "activity" tab clears the rest.
+      return {
+        entries: state.entries.filter((e) =>
+          tab === "notifications" ? e.kind !== "notification" : e.kind === "notification",
+        ),
+      };
+    }),
+
+  togglePause: () => set((state) => ({ paused: !state.paused })),
+
+  openDrawer: (tab) =>
+    set((state) => ({ drawerOpen: true, activeTab: tab ?? state.activeTab, lastSeenAt: Date.now() })),
+  closeDrawer: () => set({ drawerOpen: false }),
+  toggleDrawer: () =>
+    set((state) => ({
+      drawerOpen: !state.drawerOpen,
+      lastSeenAt: state.drawerOpen ? state.lastSeenAt : Date.now(),
+    })),
+  markSeen: () => set({ lastSeenAt: Date.now() }),
+
+  setActiveTab: (tab) => set({ activeTab: tab }),
+  setSearch: (tab, term) => set((state) => ({ search: { ...state.search, [tab]: term } })),
+  toggleKind: (tab, kind) =>
+    set((state) => {
+      const current = state.filters[tab].kinds;
+      const kinds = current.includes(kind) ? current.filter((k) => k !== kind) : [...current, kind];
+      return { filters: { ...state.filters, [tab]: { ...state.filters[tab], kinds } } };
+    }),
+  toggleSeverity: (tab, severity) =>
+    set((state) => {
+      const current = state.filters[tab].severities;
+      const severities = current.includes(severity) ? current.filter((s) => s !== severity) : [...current, severity];
+      return { filters: { ...state.filters, [tab]: { ...state.filters[tab], severities } } };
+    }),
+}));
+
+// Unread = entries newer than the last drawer open (capped to "99+" by the badge).
+export function selectUnreadCount(state: ActivityState): number {
+  let count = 0;
+  for (const entry of state.entries) {
+    if (entry.date > state.lastSeenAt) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+// ── Ingestion: system events (reused systemNotifier bus) ──────────────────────────────
+// These run at module load — coexisting with the existing appStore listeners (eventemitter3
+// supports multiple listeners per event). The drawer/footer import this module, so the
+// subscriptions are registered at app startup, not at component render.
+
+function toSystemEntry(event: SystemNotification): SystemEntry {
+  const trace = typeof event?.data?.trace === "string" ? event.data.trace : undefined;
+  return {
+    guid: event?.guid ?? crypto.randomUUID(),
+    date: event?.date instanceof Date ? event.date.getTime() : Date.now(),
+    kind: "system",
+    severity: "info",
+    title: trace ?? event?.type ?? "System event",
+    eventType: event?.type ?? "system",
+    data: event?.data,
+  };
+}
+
+systemNotifier.on("startup.phase", (event: SystemNotification) => {
+  useActivityStore.getState().ingest(toSystemEntry(event));
+});
+systemNotifier.on("engine.availability", (event: SystemNotification) => {
+  useActivityStore.getState().ingest(toSystemEntry(event));
+});
+
+// ── Ingestion: user notifications (teed from Notification.show) ────────────────────────
+
+export function intentToSeverity(intent: string | undefined): ActivitySeverity {
+  switch (intent) {
+    case "success":
+      return "success";
+    case "warning":
+      return "warning";
+    case "danger":
+      return "error";
+    default:
+      return "info"; // "primary" / "none"
+  }
+}
+
+function toNotificationEntry(event: SystemNotification): NotificationEntry {
+  const message = `${event?.data?.message ?? ""}`;
+  const intent = typeof event?.data?.intent === "string" ? event.data.intent : "none";
+  return {
+    guid: event?.guid ?? crypto.randomUUID(),
+    date: event?.date instanceof Date ? event.date.getTime() : Date.now(),
+    kind: "notification",
+    severity: intentToSeverity(intent),
+    title: message,
+    message,
+    intent,
+  };
+}
+
+systemNotifier.on("activity.notification", (event: SystemNotification) => {
+  useActivityStore.getState().ingest(toNotificationEntry(event));
+});
+
+// ── Ingestion: engine API calls (from the Api.clients interceptor) ─────────────────────
+// A "pending" event creates the entry; the matching "settled" event (same data.guid)
+// patches in status/duration/bodies/curl so a single row updates in place.
+
+function apiSeverity(status: ActivityStatus | undefined, httpStatus?: number): ActivitySeverity {
+  if (status === "error") {
+    return "error";
+  }
+  if (typeof httpStatus === "number") {
+    if (httpStatus >= 500) {
+      return "error";
+    }
+    if (httpStatus >= 400) {
+      return "warning";
+    }
+  }
+  return status === "pending" ? "info" : "success";
+}
+
+systemNotifier.on("activity.api", (event: SystemNotification) => {
+  const data: any = event?.data ?? {};
+  const store = useActivityStore.getState();
+  if (data.phase === "pending") {
+    const entry: ApiEntry = {
+      guid: data.guid,
+      date: event?.date instanceof Date ? event.date.getTime() : Date.now(),
+      kind: "api",
+      severity: "info",
+      title: `${data.method} ${data.url}`,
+      method: data.method,
+      url: data.url,
+      label: `${data.method} ${data.url}`,
+      status: "pending",
+    };
+    store.ingest(entry);
+    return;
+  }
+  store.upsert(data.guid, {
+    status: data.status,
+    severity: apiSeverity(data.status, data.httpStatus),
+    httpStatus: data.httpStatus,
+    durationMs: data.durationMs,
+    requestBody: data.requestBody,
+    curl: data.curl,
+    error: data.error,
+  } as Partial<ApiEntry>);
+});
+
+// ── Ingestion: CLI commands (from the preload ActivityBus over the contextBridge) ───────
+// Subscribed lazily/idempotently — window.ActivityBus may not exist when this module first
+// evaluates (preload race). NotificationCenterHost also calls this on mount; the preload
+// buffers entries emitted before the first subscriber, so startup CLI calls are not lost.
+
+let cliBusSubscribed = false;
+
+function toCliEntry(payload: CliBusPayload): CliEntry {
+  return {
+    guid: payload.guid,
+    date: payload.date ?? Date.now(),
+    kind: "cli",
+    severity: "info",
+    title: payload.commandLine,
+    launcher: payload.launcher,
+    args: payload.args || [],
+    invocation: payload.invocation,
+    commandLine: payload.commandLine,
+    status: "pending",
+    background: payload.background,
+  };
+}
+
+export function ensureCliBusSubscribed(): void {
+  if (cliBusSubscribed || typeof window === "undefined" || !window.ActivityBus) {
+    return;
+  }
+  cliBusSubscribed = true;
+  window.ActivityBus.subscribe((payload: CliBusPayload) => {
+    const store = useActivityStore.getState();
+    if (payload.phase === "pending") {
+      store.ingest(toCliEntry(payload));
+      return;
+    }
+    store.upsert(payload.guid, {
+      status: payload.status,
+      severity: payload.status === "error" ? "error" : "success",
+      exitCode: payload.exitCode,
+      durationMs: payload.durationMs,
+      stdoutPreview: payload.stdoutPreview,
+      stderrPreview: payload.stderrPreview,
+    } as Partial<CliEntry>);
+  });
+}
+
+ensureCliBusSubscribed();

--- a/src/web-app/stores/activityTypes.ts
+++ b/src/web-app/stores/activityTypes.ts
@@ -1,0 +1,87 @@
+// Unified entry model for the Notification Center + Activity Log.
+//
+// One in-memory, capped, NON-persisted stream feeds both drawer tabs:
+//   - "notifications" tab → kind === "notification"
+//   - "activity" tab      → kind ∈ {"api","cli","system"}
+//
+// Everything is normalized to primitives (date is epoch ms, never a Date) so that
+// CLI entries arriving over the contextBridge stay structured-cloneable and the whole
+// list sorts cheaply by `date`.
+
+export type ActivityKind = "notification" | "api" | "cli" | "system";
+export type ActivitySeverity = "info" | "success" | "warning" | "error";
+export type ActivityStatus = "pending" | "ok" | "error";
+
+export const ACTIVITY_KINDS: ActivityKind[] = ["notification", "api", "cli", "system"];
+export const ACTIVITY_SEVERITIES: ActivitySeverity[] = ["info", "success", "warning", "error"];
+
+// Kinds that belong to the "activity" tab (everything that is not a user notification).
+export const ACTIVITY_TAB_KINDS: ActivityKind[] = ["api", "cli", "system"];
+
+export interface ActivityEntryBase {
+  guid: string;
+  date: number; // epoch ms
+  kind: ActivityKind;
+  severity: ActivitySeverity;
+  title: string;
+}
+
+export interface NotificationEntry extends ActivityEntryBase {
+  kind: "notification";
+  message: string;
+  intent: string; // Blueprint Intent ("success" | "primary" | "warning" | "danger" | "none")
+}
+
+export interface ApiEntry extends ActivityEntryBase {
+  kind: "api";
+  method: string; // HTTP method
+  url: string; // path incl. query
+  label: string; // friendly label, e.g. "List containers"
+  status: ActivityStatus;
+  httpStatus?: number;
+  durationMs?: number;
+  curl?: string;
+  requestBody?: string; // JSON-stringified, truncated
+  error?: string;
+}
+
+export interface CliEntry extends ActivityEntryBase {
+  kind: "cli";
+  launcher: string;
+  args: string[];
+  invocation: "Execute" | "Spawn" | "ExecuteAsBackgroundService";
+  status: ActivityStatus;
+  exitCode?: number | null;
+  durationMs?: number;
+  commandLine: string;
+  stdoutPreview?: string;
+  stderrPreview?: string;
+  background?: boolean;
+}
+
+export interface SystemEntry extends ActivityEntryBase {
+  kind: "system";
+  eventType: string; // systemNotifier event type, e.g. "startup.phase"
+  data?: any;
+}
+
+export type ActivityEntry = NotificationEntry | ApiEntry | CliEntry | SystemEntry;
+
+// Plain payload pushed across the contextBridge by the preload CLI wrapper. Kept loose and
+// self-contained (no imports) so the preload bundle never pulls in web-app code; the store
+// normalizes it into a CliEntry. Two phases share one `guid`: "pending" then "settled".
+export interface CliBusPayload {
+  guid: string;
+  date: number;
+  phase: "pending" | "settled";
+  invocation: "Execute" | "Spawn" | "ExecuteAsBackgroundService";
+  launcher: string;
+  args: string[];
+  commandLine: string;
+  status?: ActivityStatus;
+  exitCode?: number | null;
+  durationMs?: number;
+  stdoutPreview?: string;
+  stderrPreview?: string;
+  background?: boolean;
+}

--- a/src/web-app/themes/docker.css
+++ b/src/web-app/themes/docker.css
@@ -245,3 +245,11 @@ body.bp6-light[data-engine="docker"] [data-actions-menu="container"] .ItemAction
 body.bp6-light[data-engine="docker"] .AppDataTable thead {
   background: var(--docker-light-bg-color);
 }
+
+/* Notification Center — Docker accent for the active segment of the switcher.
+   Harnesses Blueprint's ButtonGroup active state (.bp6-active), tinted per engine. */
+body[data-engine="docker"] .NotificationCenterSwitch .bp6-button.bp6-active,
+body[data-engine="docker"] .NotificationCenterSwitch .bp6-button.bp6-active:hover {
+  background-color: #2f6fd6;
+  color: #fff;
+}

--- a/src/web-app/themes/podman.css
+++ b/src/web-app/themes/podman.css
@@ -274,3 +274,11 @@ body.bp6-light[data-engine="podman"] [data-actions-menu="container"] .ItemAction
 body.bp6-light .AppDataTable thead {
   background: #dcdcdc;
 }
+
+/* Notification Center — Podman accent for the active segment of the switcher.
+   Harnesses Blueprint's ButtonGroup active state (.bp6-active), tinted per engine. */
+body[data-engine="podman"] .NotificationCenterSwitch .bp6-button.bp6-active,
+body[data-engine="podman"] .NotificationCenterSwitch .bp6-button.bp6-active:hover {
+  background-color: #9b3fb5;
+  color: #fff;
+}


### PR DESCRIPTION
## What

A right-side **Notification Center** drawer, opened from a bell at the far-right of the footer, with two tabs:

- **Notifications** — history of the app's existing toasts (`Notification.show`), now teed into an in-renderer event bus.
- **Activity** — a filterable log of every engine **API** and **CLI** interaction, doubling as live documentation for people learning containers: friendly labels ("List containers"), HTTP status + duration badges, exit codes, and an expandable **Equivalent cURL** (`curl --unix-socket …`) with one-click copy.

Filter by text, kind (API/CLI/System) and severity; consecutive duplicates collapse; Pause/Clear in the header. **In-memory only** (no persistence, capped ring buffer), engine/theme-aware (podman/docker, light/dark).

## How

- Reuses the existing `Notification.show` + `systemNotifier` bus — no new emit API; ~70 call sites unchanged.
- **API** captured at the single renderer funnel (`createApplicationApiDriver.request` → `Command.ProxyRequest`).
- **CLI** captured by wrapping `Command` in `preload.ts` before `exposeInMainWorld`, delivered to the renderer via a new `ActivityBus` over the contextBridge (buffers startup calls until the store subscribes).
- One Zustand store; the per-screen footer bell only toggles state, the drawer is mounted once in `AppLayout`.

## Verification

- `yarn check-types`, `yarn lint`, `yarn test:run` (50 pass, incl. new `endpointLabels` + `activityFilters` specs), and `cross-env ENVIRONMENT=production yarn build` — all green (preload still bundles to CJS with `ActivityBus` exposed).
- Driven end-to-end over CDP against `yarn dev`: notifications, API + CLI entries, filters, expand/copy, light+dark / docker theming.

## Notes

- Response bodies are intentionally not captured (keeps the log compact).
- The bell's far-right spot overlaps the TanStack Query Devtools button in **dev only**; it isn't present in packaged builds.
- Version/release intentionally untouched; CHANGELOG updated under `[Unreleased]`.
