### PR TITLE
CDP machinery to drive the real Electron app (Playwright E2E foundation)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:live": "vitest run --config vitest.live.config.mts",
+    "test:ui": "vitest run --config vitest.ui.config.mts",
     "watch": "node support/watch.mjs",
     "postinstall": "cross-env ELECTRON_RUN_AS_NODE=1 yarn electron support/update-electron-vendors.mjs"
   },
@@ -95,6 +96,7 @@
     "electron-builder": "^26.15.3",
     "jsdom": "^26.1.0",
     "mime-types": "^3.0.2",
+    "playwright-core": "1.61.0",
     "postcss": "^8.5.15",
     "svgo": "^4.0.1",
     "tslib": "^2.8.1",

--- a/src/__tests__/ui/app-harness.ts
+++ b/src/__tests__/ui/app-harness.ts
@@ -1,0 +1,129 @@
+// CDP machinery for driving the real Electron app from tests — the two standard Electron+Vite shapes:
+//
+//   launchApp()    — Playwright launches the BUILT app (self-contained E2E). Needs a production build;
+//                    a real window appears. This is the canonical `_electron.launch` pattern and works
+//                    because main.ts loads file:// for any prod build (packaged or not), not just packaged.
+//   connectToApp() — attach over CDP to an already-running instance, e.g. `yarn dev` (hot reload) which
+//                    exposes :9222. Use this to drive the live dev app while iterating.
+//
+// Both return a Playwright Page bound to the renderer, once the preload bridge (window.Preloaded) is up.
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { type Browser, chromium, type ElectronApplication, _electron as electron, type Page } from "playwright-core";
+
+const require = createRequire(import.meta.url);
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const DEFAULT_ENDPOINT = `http://localhost:${process.env.CONTAINER_DESKTOP_REMOTE_DEBUGGING_PORT || "9222"}`;
+
+// GPU flags only when headless (CI). Never on the default path — they caused a GPU crash-loop (CLAUDE.md).
+const HEADLESS_GPU_ARGS = [
+  "--disable-gpu",
+  "--disable-gpu-sandbox",
+  "--in-process-gpu",
+  "--no-zygote",
+  "--disable-features=VizDisplayCompositor",
+  "--disable-dev-shm-usage",
+  "--disable-web-security",
+];
+
+export function headlessFromEnv(): boolean {
+  return ["1", "true", "yes"].includes(`${process.env.CONTAINER_DESKTOP_HEADLESS || ""}`.toLowerCase());
+}
+
+/** Absolute path to the packaged main entry (build/<version>/main.cjs). */
+export function productionMainPath(): string {
+  const version = require(path.join(ROOT, "package.json")).version as string;
+  return path.join(ROOT, "build", version, "main.cjs");
+}
+
+export interface AppSession {
+  page: Page;
+  app?: ElectronApplication;
+  browser?: Browser;
+  /** Close the launched app (launchApp) or disconnect from the attached one (connectToApp). */
+  close: () => Promise<void>;
+}
+
+const waitForPreloaded = (page: Page, timeoutMs: number) =>
+  page.waitForFunction(() => (window as unknown as { Preloaded?: boolean }).Preloaded === true, undefined, {
+    timeout: timeoutMs,
+  });
+
+/** Launch the BUILT app under Playwright (CDP-driven). Requires `cross-env ENVIRONMENT=production yarn build`. */
+export async function launchApp(opts?: { headless?: boolean; preloadTimeoutMs?: number }): Promise<AppSession> {
+  const mainPath = productionMainPath();
+  if (!existsSync(mainPath)) {
+    throw new Error(`No production build at ${mainPath}. Run:  cross-env ENVIRONMENT=production yarn build`);
+  }
+  const args = [mainPath, "--no-sandbox"];
+  if (opts?.headless ?? headlessFromEnv()) {
+    args.push(...HEADLESS_GPU_ARGS);
+  }
+
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) {
+      env[key] = value;
+    }
+  }
+  env.ENVIRONMENT = "production";
+  // Electron must NOT inherit ELECTRON_RUN_AS_NODE — with it set it boots as plain Node and the
+  // electron API is missing, so startup fails (CLAUDE.md).
+  delete env.ELECTRON_RUN_AS_NODE;
+
+  const app = await electron.launch({ executablePath: require("electron") as string, args, env });
+  const page = await app.firstWindow();
+  await waitForPreloaded(page, opts?.preloadTimeoutMs ?? 30_000);
+  const close = async () => {
+    // app.close() can hang if the app holds background work open — force-kill the process on timeout.
+    try {
+      await Promise.race([
+        app.close(),
+        new Promise((_, reject) => setTimeout(() => reject(new Error("close timeout")), 8000)),
+      ]);
+    } catch {
+      try {
+        app.process()?.kill("SIGKILL");
+      } catch {
+        /* already gone */
+      }
+    }
+  };
+  return { page, app, close };
+}
+
+/** Attach to a running instance over CDP (e.g. `yarn dev` exposes :9222). Disconnects on close; app keeps running. */
+export async function connectToApp(opts?: { endpoint?: string; preloadTimeoutMs?: number }): Promise<AppSession> {
+  const endpoint = opts?.endpoint ?? DEFAULT_ENDPOINT;
+  const browser = await chromium.connectOverCDP(endpoint);
+  const timeoutMs = opts?.preloadTimeoutMs ?? 30_000;
+
+  const deadline = Date.now() + timeoutMs;
+  let page: Page | undefined;
+  while (!page && Date.now() < deadline) {
+    for (const context of browser.contexts()) {
+      for (const candidate of context.pages()) {
+        const ready = await candidate
+          .evaluate(() => (window as unknown as { Preloaded?: boolean }).Preloaded === true)
+          .catch(() => false);
+        if (ready) {
+          page = candidate;
+          break;
+        }
+      }
+      if (page) {
+        break;
+      }
+    }
+    if (!page) {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+  }
+  if (!page) {
+    await browser.close().catch(() => {});
+    throw new Error(`No renderer page with the preload bridge (window.Preloaded) at ${endpoint} within ${timeoutMs}ms`);
+  }
+  return { page, browser, close: () => browser.close() };
+}

--- a/src/__tests__/ui/smoke.live.test.ts
+++ b/src/__tests__/ui/smoke.live.test.ts
@@ -1,0 +1,41 @@
+import { existsSync } from "node:fs";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { type AppSession, headlessFromEnv, launchApp, productionMainPath } from "./app-harness";
+
+// Smallest possible CDP machinery check: launch the packaged app, confirm the preload bridge comes up
+// and the window renders. Real UI assertions come later. Skips loudly when it can't run.
+const skipReason = !existsSync(productionMainPath())
+  ? "no production build — run `cross-env ENVIRONMENT=production yarn build`"
+  : process.platform === "linux" && !process.env.DISPLAY && !headlessFromEnv()
+    ? "no DISPLAY on Linux — run under a display, or set CONTAINER_DESKTOP_HEADLESS=1 (with xvfb)"
+    : null;
+
+if (skipReason) {
+  console.warn(`[ui] smoke skipped: ${skipReason}`);
+}
+
+const suite = skipReason ? describe.skip : describe;
+
+suite("app CDP smoke", () => {
+  let session: AppSession;
+
+  beforeAll(async () => {
+    session = await launchApp();
+  }, 60_000);
+
+  afterAll(async () => {
+    await session?.close().catch(() => {});
+  });
+
+  it("brings up the renderer with the preload bridge ready", async () => {
+    const ready = await session.page.evaluate(() => (window as unknown as { Preloaded?: boolean }).Preloaded === true);
+    expect(ready).toBe(true);
+  });
+
+  it("renders a titled window with body content", async () => {
+    expect(await session.page.title()).toBeTruthy();
+    await session.page.waitForSelector("body", { timeout: 10_000 });
+    const childCount = await session.page.evaluate(() => document.body.childElementCount);
+    expect(childCount).toBeGreaterThan(0);
+  });
+});

--- a/src/electron-shell/main.ts
+++ b/src/electron-shell/main.ts
@@ -86,11 +86,17 @@ const setWindowConfigOptions = debounce(async (opts: Electron.BrowserWindowConst
 }, 500);
 const isDebug = ["yes", "true", "1"].includes(`${process.env.CONTAINER_DESKTOP_DEBUG || ""}`.toLowerCase());
 const isDevelopment = () => {
+  // Standard Vite-Electron rule: development iff the build was made in development mode OR a Vite
+  // dev-server URL was injected (hot reload). NOT keyed on app.isPackaged — an unpackaged *production*
+  // build launched directly (e.g. Playwright `electron.launch` in E2E tests) must behave as production.
+  const dev = import.meta.env.ENVIRONMENT === "development" || Boolean(import.meta.env.VITE_DEV_SERVER_URL);
   logger.debug("Checking if development", {
     isPackaged: app.isPackaged,
     env: import.meta.env.ENVIRONMENT,
+    devServer: Boolean(import.meta.env.VITE_DEV_SERVER_URL),
+    dev,
   });
-  return !app.isPackaged || import.meta.env.ENVIRONMENT === "development";
+  return dev;
 };
 const activateTools = () => {
   if (isDevelopment() || isDebug) {
@@ -267,7 +273,9 @@ async function createApplicationWindow() {
     protocol: "file:",
     slashes: true,
   });
-  const appURL = isDevelopment() ? appDevURL : appProdURL;
+  // Use the dev server when present (hot reload), otherwise the built renderer from file:// — works
+  // packaged AND for an unpackaged production build launched directly (Playwright in E2E tests).
+  const appURL = appDevURL || appProdURL;
   const iconFile = CURRENT_OS_TYPE === OperatingSystem.MacOS ? "appIcon.png" : "appIcon-duotone.png";
   const iconPath = isDevelopment()
     ? path.join(PROJECT_HOME, "src/resources/icons", iconFile)

--- a/vitest.live.config.mts
+++ b/vitest.live.config.mts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 // LIVE connectivity suite — runs against the owner's real machines (see src/__tests__/live). Kept in a
 // separate project so it never runs in the hermetic/CI run. Select targets with
@@ -11,6 +11,8 @@ export default defineConfig({
   },
   test: {
     include: ["src/**/*.live.test.{ts,tsx}"],
+    // The UI suite (Electron/CDP) has its own project (vitest.ui.config.mts) — keep it out of here.
+    exclude: [...configDefaults.exclude, "src/__tests__/ui/**"],
     environment: "node",
     // Wire the platform globals (Platform/Path/FS/CURRENT_OS_TYPE). Tests opt into the real spawning
     // Command via installRealCommand() from the same module.

--- a/vitest.ui.config.mts
+++ b/vitest.ui.config.mts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+
+// UI automation project — drives the real Electron app over CDP (Playwright). Separate from the
+// hermetic run and from the connection live suite: it launches an actual app window, so it needs a
+// production build and a display (or CONTAINER_DESKTOP_HEADLESS=1 + xvfb). Run with `yarn test:ui`.
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": new URL("./src", import.meta.url).pathname,
+    },
+  },
+  test: {
+    include: ["src/__tests__/ui/**/*.live.test.{ts,tsx}"],
+    environment: "node",
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
+    // One Electron instance at a time.
+    fileParallelism: false,
+    globals: false,
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3875,6 +3875,11 @@ pkijs@^3.4.0:
     pvutils "^1.1.3"
     tslib "^2.8.1"
 
+playwright-core@1.61.0:
+  version "1.61.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.61.0.tgz#caf8078b2a39cd7738dc75ec11cb3b47f385c3f0"
+  integrity sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==
+
 please-upgrade-node@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"


### PR DESCRIPTION
Foundation for UI automation — the machinery to drive the real app over CDP. **Actual UI tests come later** (per request); this lands the harness + a root-cause startup fix, validated by a minimal smoke.

## Root-cause fix (main.ts)
`isDevelopment()` keyed off `!app.isPackaged`, so an **unpackaged production build launched directly** (Playwright `electron.launch`) was treated as dev, looked for a Vite dev-server URL it didn't have, and showed *"No application URL resolved"*. Now the renderer URL follows the **standard Vite-Electron rule** — use the dev-server URL when present (hot reload), else load `file://` — decoupled from packaging. **`yarn dev` hot reload and packaged prod are unchanged**; only the unpackaged-prod-build case is fixed (which is what E2E needs).

## Machinery (`src/__tests__/ui/app-harness.ts`)
- `launchApp()` — Playwright `_electron.launch` of the built app (self-contained E2E; a real window appears). Strips `ELECTRON_RUN_AS_NODE`, robust force-kill teardown.
- `connectToApp()` — attach over CDP to a running `yarn dev` (:9222) to drive the hot-reload instance.
- Both return a Playwright `Page` once `window.Preloaded` is up.

## Smoke + wiring
- `smoke.live.test.ts` (launch → preload bridge ready → titled window with body), `vitest.ui.config.mts`, `yarn test:ui`. Excluded from the hermetic run and from `test:live`. `playwright-core` pinned (no bundled browsers).

## Verification
`yarn test:ui` green (2/2) against a real launched window · `check-types` · `lint:check` (314 files) · hermetic suite 97 — all green.

Run: `cross-env ENVIRONMENT=production yarn build && yarn test:ui` (or attach to `yarn dev` via `connectToApp()`).