### PR TITLE
fix: surface connection availability reason in the UI (#186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The development watcher no longer deletes `preload.cjs` after the preload build completes.
 - Monaco is bundled locally instead of being loaded from a CDN.
 - Remote SSH on Linux and macOS now verifies host keys instead of disabling the check, preventing man-in-the-middle attacks.
-- Remote SSH connections no longer hang indefinitely on "Please wait": the control connection is bounded (non-interactive, with a connect timeout) and a non-default SSH port is no longer dropped. When a connection fails, the app now reports the specific cause — missing ssh client, identity file not found, key permissions too open, host unreachable, or remote engine not running — instead of failing silently with no reason. (#171, #186)
+- Remote SSH connections no longer hang indefinitely on "Please wait": the control connection is bounded (non-interactive, with a connect timeout) and a non-default SSH port is no longer dropped. When a connection fails, the app now reports the specific cause — missing ssh client, identity file not found, key permissions too open, host unreachable, or remote engine not running — instead of failing silently with no reason. The cause is shown in the Settings connection list, on the connection's Connect button and in the startup notification, naming the exact step that failed. (#171, #186)
 
 ## [5.2.16] - 2026-06-14
 

--- a/src/web-app/screens/Settings/ActionsMenu.tsx
+++ b/src/web-app/screens/Settings/ActionsMenu.tsx
@@ -7,6 +7,7 @@ import type { Connection } from "@/env/Types";
 import { ConfirmMenu } from "@/web-app/components/ConfirmMenu";
 import { Notification } from "@/web-app/Notification";
 import { useAppStore } from "@/web-app/stores/appStore";
+import { getFirstUnavailableReason } from "@/web-app/utils/availability";
 
 import "./ActionsMenu.css";
 
@@ -113,6 +114,8 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = ({ connection, onEdit }: 
   }, [setGlobalUserSettings, connection]);
   const isCurrent = currentConnector?.connectionId === connection?.id;
   const isConnected = isCurrent && currentConnector.availability.api;
+  const unavailableReason =
+    isCurrent && !isConnected ? getFirstUnavailableReason(currentConnector.availability) : undefined;
 
   const removeWidget = connection ? (
     <ConfirmMenu
@@ -135,7 +138,7 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = ({ connection, onEdit }: 
           icon={isConnected ? IconNames.POWER : IconNames.OFFLINE}
           intent={isConnected ? Intent.SUCCESS : Intent.NONE}
           text={isConnected ? t("Disconnect") : t("Connect")}
-          title={t("Connect")}
+          title={!isConnected && unavailableReason?.reason ? unavailableReason.reason : t("Connect")}
           onClick={isConnected ? onDisconnectClick : onConnectClick}
         />
       </ButtonGroup>

--- a/src/web-app/screens/Settings/UserSettingsScreen.css
+++ b/src/web-app/screens/Settings/UserSettingsScreen.css
@@ -120,7 +120,7 @@
   overflow: auto;
 }
 [data-running="no"] .AppSettingsEngineManagerConnections {
-  height: calc(100vh - 520px);
+  height: calc(100vh - 544px);
 }
 .AppSettingsEngineManagerConnections [data-table="host.connections"] thead {
   position: sticky;
@@ -182,6 +182,12 @@
 .PlatformConnectionDescription {
   padding-top: 5px;
   color: #999;
+}
+.PlatformConnectionError {
+  margin: 0;
+  padding-top: 5px;
+  font-size: 11px;
+  color: #cd4246;
 }
 
 [data-connection-is-system="yes"] .PlatformConnectionName {

--- a/src/web-app/screens/Settings/UserSettingsScreen.tsx
+++ b/src/web-app/screens/Settings/UserSettingsScreen.tsx
@@ -29,6 +29,7 @@ import { LOGGING_LEVELS, PROJECT_VERSION } from "@/web-app/Environment";
 import { Notification } from "@/web-app/Notification";
 import { useAppStore } from "@/web-app/stores/appStore";
 import type { AppScreen, AppScreenProps } from "@/web-app/Types";
+import { getFirstUnavailableReason } from "@/web-app/utils/availability";
 import { ActionsMenu } from "./ActionsMenu";
 import { ManageConnectionDrawer } from "./Connection";
 import { ScreenHeader } from "./ScreenHeader";
@@ -321,6 +322,8 @@ export const Screen: AppScreen<ScreenProps> = () => {
                     runtimeEngineLabelsMap[`${connection.engine}:${connection.host}`] || connection.host;
                   const isCurrent = currentConnector?.connectionId === connection?.id;
                   const isConnected = isCurrent && currentConnector.availability.api;
+                  const unavailableReason =
+                    isCurrent && !isConnected ? getFirstUnavailableReason(currentConnector.availability) : undefined;
                   const isAutomatic = connection.settings.mode === "mode.automatic";
                   const descriptions = [connection.settings?.api?.connection?.uri || "", connection.description || ""];
                   const description = descriptions.filter((it) => !isEmpty(it)).join(". ");
@@ -340,6 +343,14 @@ export const Screen: AppScreen<ScreenProps> = () => {
                       <td>
                         <p className="PlatformConnectionName">{connection.name}</p>
                         {description ? <p className="PlatformConnectionDescription">{description}</p> : null}
+                        {unavailableReason?.reason ? (
+                          <p
+                            className="PlatformConnectionError"
+                            data-availability-dimension={unavailableReason.dimension}
+                          >
+                            {unavailableReason.reason}
+                          </p>
+                        ) : null}
                       </td>
                       <td>{connection.engine}</td>
                       <td>

--- a/src/web-app/stores/appStore.ts
+++ b/src/web-app/stores/appStore.ts
@@ -35,6 +35,7 @@ import { Notification } from "@/web-app/Notification";
 import { resourceEvents } from "@/web-app/stores/resourceEvents";
 import { useResourceStore } from "@/web-app/stores/resourceStore";
 import { useUIStore } from "@/web-app/stores/uiStore";
+import { getFirstUnavailableReason } from "@/web-app/utils/availability";
 
 export const DEFAULT_SYSTEM_CONNECTION_ID = "system-default.podman";
 
@@ -276,8 +277,14 @@ export const useAppStore = create<AppStore>()((set, get) => {
                 intent: Intent.SUCCESS,
               });
             } else {
+              const unavailable = getFirstUnavailableReason(currentConnector.availability);
               Notification.show({
-                message: t("Connection skipped - please check the settings or install the requirements"),
+                message: unavailable?.reason
+                  ? t("Connection to {{name}} failed: {{reason}}", {
+                      name: currentConnector.name,
+                      reason: unavailable.reason,
+                    })
+                  : t("Connection skipped - please check the settings or install the requirements"),
                 intent: Intent.WARNING,
               });
             }

--- a/src/web-app/utils/availability.test.ts
+++ b/src/web-app/utils/availability.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import type { EngineConnectorAvailability } from "@/env/Types";
+
+import { getFirstUnavailableReason } from "./availability";
+
+// Build a fully-available report, then let each test fail one dimension.
+function availability(
+  overrides: Partial<Omit<EngineConnectorAvailability, "report">> & {
+    report?: Partial<EngineConnectorAvailability["report"]>;
+  } = {},
+): EngineConnectorAvailability {
+  const { report, ...rest } = overrides;
+  return {
+    enabled: true,
+    host: true,
+    controller: true,
+    controllerScope: true,
+    program: true,
+    api: true,
+    ...rest,
+    report: {
+      host: "Host is available",
+      controller: "Controller is available",
+      controllerScope: "Controller scope is available",
+      program: "Program is available",
+      api: "API is running",
+      ...(report ?? {}),
+    },
+  };
+}
+
+describe("getFirstUnavailableReason", () => {
+  it("returns undefined when the API is running (connected)", () => {
+    expect(getFirstUnavailableReason(availability())).toBeUndefined();
+  });
+
+  it("returns undefined when availability is missing", () => {
+    expect(getFirstUnavailableReason(undefined)).toBeUndefined();
+  });
+
+  it("reports the host as the root cause when the host is unreachable", () => {
+    const result = getFirstUnavailableReason(
+      availability({
+        host: false,
+        controller: false,
+        controllerScope: false,
+        program: false,
+        api: false,
+        report: {
+          host: "host unreachable: timeout",
+          controller: "Not checked - host not available",
+          controllerScope: "Not checked - controller not available",
+          program: "Not checked - controller scope not available",
+          api: "API is not running",
+        },
+      }),
+    );
+    expect(result).toEqual({ dimension: "host", reason: "host unreachable: timeout" });
+  });
+
+  it("reports the controller when the host is up but the controller is missing", () => {
+    const result = getFirstUnavailableReason(
+      availability({
+        controller: false,
+        controllerScope: false,
+        program: false,
+        api: false,
+        report: { controller: "podman.exe not found in path" },
+      }),
+    );
+    expect(result).toEqual({ dimension: "controller", reason: "podman.exe not found in path" });
+  });
+
+  it("reports the program when the scope is up but the program is missing", () => {
+    const result = getFirstUnavailableReason(
+      availability({
+        program: false,
+        api: false,
+        report: { program: "podman not installed in the distribution" },
+      }),
+    );
+    expect(result).toEqual({ dimension: "program", reason: "podman not installed in the distribution" });
+  });
+
+  it("reports the API when everything upstream is available but the socket is down", () => {
+    const result = getFirstUnavailableReason(availability({ api: false, report: { api: "podman.sock missing" } }));
+    expect(result).toEqual({ dimension: "api", reason: "podman.sock missing" });
+  });
+
+  it("skips inapplicable controller/controllerScope dimensions for native hosts", () => {
+    // Native hosts have no controller — those booleans are undefined and must NOT be reported as failures.
+    const result = getFirstUnavailableReason(
+      availability({
+        controller: undefined,
+        controllerScope: undefined,
+        api: false,
+        report: {
+          controller: undefined,
+          controllerScope: undefined,
+          api: "API is not running",
+        },
+      }),
+    );
+    expect(result).toEqual({ dimension: "api", reason: "API is not running" });
+  });
+});

--- a/src/web-app/utils/availability.ts
+++ b/src/web-app/utils/availability.ts
@@ -1,0 +1,34 @@
+import type { EngineConnectorAvailability } from "@/env/Types";
+
+export type AvailabilityDimension = "host" | "controller" | "controllerScope" | "program" | "api";
+
+export interface UnavailableReason {
+  dimension: AvailabilityDimension;
+  reason: string;
+}
+
+// Dependency order: an upstream failure is the root cause of every downstream check,
+// so the first failing dimension in this order is the most useful reason to surface.
+const DIMENSION_ORDER: AvailabilityDimension[] = ["host", "controller", "controllerScope", "program", "api"];
+
+/**
+ * Derive the most relevant "why is this connection not available" reason from an
+ * availability report. Returns `undefined` when the API is running (connected) or
+ * when no availability is known. Optional dimensions (controller/controllerScope)
+ * are `undefined` for native hosts and are skipped rather than treated as failures.
+ */
+export function getFirstUnavailableReason(availability?: EngineConnectorAvailability): UnavailableReason | undefined {
+  if (!availability || availability.api) {
+    return undefined;
+  }
+  for (const dimension of DIMENSION_ORDER) {
+    const ok = availability[dimension];
+    if (ok === undefined) {
+      continue;
+    }
+    if (!ok) {
+      return { dimension, reason: availability.report?.[dimension] ?? "" };
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Why

The SSH pre-flight backend (shipped in #218) already computes *why* a connection is unavailable — missing ssh client, identity not found, key permissions too open, host unreachable, remote engine not running — and fills `availability.report.*`. But the renderer only read `availability.api` and showed a generic *"Connection skipped — please check the settings…"*. So the user still saw **no reason** — the visible half of #186.

## What

Surface the real `report.*` reason at the three seams where connection state already renders:

- **`getFirstUnavailableReason()`** (`web-app/utils/availability.ts`) — returns the first failing dimension in dependency order (`host → controller → controllerScope → program → api`), skipping optional dimensions that don't apply to native hosts. Pure function, 7 hermetic tests.
- **Startup toast** (`appStore`) — names the failing step instead of the generic message.
- **Settings connection list** — the current/not-connected row shows the reason (`.PlatformConnectionError`, `data-availability-dimension`).
- **Connect button** (`ActionsMenu`) — carries the reason in its `title` on hover.

No new screens; reads a field that was already populated.

## Verify

- `yarn check-types` ✅ · `yarn lint:check` ✅ (316 files) · `yarn test:run` ✅ **104** (was 97; +7 `availability`)
- `cross-env ENVIRONMENT=production yarn build` ✅ → `yarn test:ui` CDP smoke ✅ **2/2** (real Electron boots + renders post-change)

Closes #186.