### PR TITLE
Feat/bulk list operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
-- Removed the unread counter badge from the header notifications bell.
+- Notifications & activity log: the bell fills white when there are unread entries (counter badge removed); API response bodies and CLI output now show only for failed calls.
 
 ## [5.3.0] - 2026-06-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+- Bulk (mass) operations on the list screens of Containers, Pods, Machines, Images, Volumes, Networks and Secrets — multi-select rows with delete and lifecycle actions (stop/pause/start/restart).
+
+## Changed
+
+- Removed the unread counter badge from the header notifications bell.
+
 ## [5.3.0] - 2026-06-15
 
 ## Added

--- a/src/container-client/Api.clients.ts
+++ b/src/container-client/Api.clients.ts
@@ -52,8 +52,9 @@ export async function getApiConfig(
 // ── Activity Log instrumentation ───────────────────────────────────────────────────────
 // Every engine API call funnels through createApplicationApiDriver.request(); we emit a
 // "pending" entry immediately and patch a "settled" entry (status + duration) by guid so
-// long calls surface at once. The request body is stringified + truncated for memory; the
-// response body is intentionally not captured.
+// long calls surface at once. The request body is stringified + truncated for memory; the response
+// body is captured (stringified + truncated) only for unsuccessful responses (4xx/5xx) so failures can
+// be inspected without retaining every successful payload.
 const ACTIVITY_MAX_BODY = 8 * 1024;
 
 function activityStringify(value: unknown): string | undefined {
@@ -114,6 +115,7 @@ export function createApplicationApiDriver(connection: Connection, context?: any
         httpStatus: response?.status,
         durationMs: Math.round(performance.now() - startedAt),
         requestBody: activityTruncate(activityStringify(req.data)),
+        responseBody: response?.status >= 300 ? activityTruncate(activityStringify(response?.data)) : undefined,
         curl: activityCurl(req, connection),
       });
       return response;
@@ -128,6 +130,7 @@ export function createApplicationApiDriver(connection: Connection, context?: any
         durationMs: Math.round(performance.now() - startedAt),
         error: `${error?.message || error}`,
         requestBody: activityTruncate(activityStringify(req.data)),
+        responseBody: activityTruncate(activityStringify(error?.response?.data)),
         curl: activityCurl(req, connection),
       });
       throw error;

--- a/src/web-app/App.css
+++ b/src/web-app/App.css
@@ -178,6 +178,13 @@ pre,
 .AppDataTable tbody td:last-child {
   width: 1px !important;
 }
+/* When a bulk selection column is present (always the last column), the row Actions column moves to
+   second-to-last. Keep it shrink-to-fit for BOTH header and cells (the global :last-child rule above now
+   sizes the selection column instead). */
+.AppDataTable thead th:has(+ th.BulkSelectColumn),
+.AppDataTable tbody td:has(+ td.BulkSelectColumn) {
+  width: 1px !important;
+}
 .AppDataTable thead th[data-column="Actions"] {
   width: 1px;
 }

--- a/src/web-app/components/Bulk/BulkActionsBar.css
+++ b/src/web-app/components/Bulk/BulkActionsBar.css
@@ -1,0 +1,26 @@
+.BulkActionsInline {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-right: 12px;
+}
+
+/* The selection column is always rendered (checkbox only shown in select mode) and kept a constant
+   width so toggling select mode never shifts the other columns. */
+.BulkSelectColumn {
+  width: 36px !important;
+  min-width: 36px;
+  text-align: center;
+}
+
+.BulkSelectionCheckbox {
+  margin: 0;
+}
+
+.BulkConfirmPopover {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  white-space: nowrap;
+}

--- a/src/web-app/components/Bulk/BulkActionsBar.tsx
+++ b/src/web-app/components/Bulk/BulkActionsBar.tsx
@@ -1,0 +1,134 @@
+// components/Bulk/BulkActionsBar.tsx — the inline bulk-action controls shown in a list screen's header
+// (next to Search + the Select toggle) while select mode is on. Lifecycle actions are minimal icon-only
+// buttons (label as tooltip) to save horizontal space; the destructive Remove keeps its label, sits after
+// a divider, and confirms via a Yes/No PopoverNext (the same popover-confirm pattern as ConfirmMenu — no
+// dialogs). Each button is disabled when no selected item is eligible. After any run it refreshes the list
+// once and clears the selection. Exiting select mode is handled by the Select toggle, so there is no Done.
+
+import { Button, ButtonGroup, Divider, Intent, PopoverNext } from "@blueprintjs/core";
+import { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { BulkAction } from "./types";
+import { useBulkRunner } from "./useBulkRunner";
+import "./BulkActionsBar.css";
+
+interface BulkActionsBarProps<T> {
+  items: T[];
+  getId: (item: T) => string;
+  selectedIds: Set<string>;
+  // Either a fixed list, or a function of the current selection so screens can render state-aware
+  // controls (e.g. a single play/pause toggle whose icon depends on the selected containers' states).
+  actions: BulkAction<T>[] | ((selected: T[]) => BulkAction<T>[]);
+  onClear: () => void;
+  refresh: () => Promise<void> | void;
+}
+
+export function BulkActionsBar<T>({ items, getId, selectedIds, actions, onClear, refresh }: BulkActionsBarProps<T>) {
+  const { t } = useTranslation();
+  const { run, runningKey } = useBulkRunner<T>();
+  const [confirmKey, setConfirmKey] = useState<string | undefined>();
+
+  const selectedItems = useMemo(
+    () => items.filter((item) => selectedIds.has(getId(item))),
+    [items, getId, selectedIds],
+  );
+  const resolvedActions = useMemo(
+    () => (typeof actions === "function" ? actions(selectedItems) : actions),
+    [actions, selectedItems],
+  );
+
+  const execute = useCallback(
+    async (action: BulkAction<T>) => {
+      const eligible = selectedItems.filter(action.eligible);
+      if (eligible.length === 0) {
+        return;
+      }
+      await run(action, eligible);
+      await refresh();
+      onClear();
+    },
+    [selectedItems, run, refresh, onClear],
+  );
+
+  const busy = runningKey !== undefined;
+  const count = selectedItems.length;
+
+  const renderButton = (action: BulkAction<T>, eligibleCount: number) => (
+    <Button
+      small
+      minimal={!action.destructive}
+      data-bulk-action={action.key}
+      icon={action.icon}
+      intent={action.intent}
+      text={action.destructive ? action.label : undefined}
+      disabled={busy || eligibleCount === 0}
+      loading={runningKey === action.key}
+      title={
+        eligibleCount === 0
+          ? t("No selected items are eligible for {{label}}", { label: action.label })
+          : t("{{label}} {{eligibleCount}} of {{count}}", { label: action.label, eligibleCount, count })
+      }
+      onClick={() => (action.destructive ? setConfirmKey(action.key) : void execute(action))}
+    />
+  );
+
+  const renderAction = (action: BulkAction<T>) => {
+    const eligibleCount = selectedItems.filter(action.eligible).length;
+    if (!action.destructive) {
+      return <span key={action.key}>{renderButton(action, eligibleCount)}</span>;
+    }
+    return (
+      <PopoverNext
+        key={action.key}
+        isOpen={confirmKey === action.key}
+        onInteraction={(next) => setConfirmKey(next ? action.key : undefined)}
+        usePortal
+        hasBackdrop={false}
+        placement="bottom-end"
+        content={
+          <div className="BulkConfirmPopover">
+            <span className="BulkConfirmPopoverText">
+              {t("{{label}} {{count}} selected?", { label: action.label, count: eligibleCount })}
+            </span>
+            <ButtonGroup>
+              <Button
+                small
+                minimal
+                intent={Intent.DANGER}
+                text={t("Yes")}
+                data-bulk-confirm="yes"
+                onClick={() => {
+                  setConfirmKey(undefined);
+                  void execute(action);
+                }}
+              />
+              <Button
+                small
+                minimal
+                intent={Intent.SUCCESS}
+                text={t("No")}
+                data-bulk-confirm="no"
+                onClick={() => setConfirmKey(undefined)}
+              />
+            </ButtonGroup>
+          </div>
+        }
+      >
+        {renderButton(action, eligibleCount)}
+      </PopoverNext>
+    );
+  };
+
+  const lifecycle = resolvedActions.filter((action) => !action.destructive);
+  const destructive = resolvedActions.filter((action) => action.destructive);
+
+  return (
+    <span className="BulkActionsInline" data-bulk-bar="true">
+      <ButtonGroup>
+        {lifecycle.map(renderAction)}
+        {lifecycle.length > 0 && destructive.length > 0 ? <Divider /> : null}
+        {destructive.map(renderAction)}
+      </ButtonGroup>
+    </span>
+  );
+}

--- a/src/web-app/components/Bulk/SelectionCheckbox.tsx
+++ b/src/web-app/components/Bulk/SelectionCheckbox.tsx
@@ -1,0 +1,22 @@
+// components/Bulk/SelectionCheckbox.tsx — the checkbox used in the select-all header cell and per-row
+// cells. Stops click propagation so it never triggers the row's hover/focus/overlay handlers.
+
+import { Checkbox } from "@blueprintjs/core";
+
+interface SelectionCheckboxProps {
+  checked: boolean;
+  indeterminate?: boolean;
+  onChange: () => void;
+  title?: string;
+}
+
+export const SelectionCheckbox: React.FC<SelectionCheckboxProps> = ({ checked, indeterminate, onChange, title }) => (
+  <Checkbox
+    className="BulkSelectionCheckbox"
+    checked={checked}
+    indeterminate={indeterminate}
+    onChange={() => onChange()}
+    onClick={(e) => e.stopPropagation()}
+    title={title}
+  />
+);

--- a/src/web-app/components/Bulk/index.ts
+++ b/src/web-app/components/Bulk/index.ts
@@ -1,0 +1,6 @@
+// components/Bulk/index.ts — public surface of the bulk (mass) operations toolkit.
+
+export { BulkActionsBar } from "./BulkActionsBar";
+export { SelectionCheckbox } from "./SelectionCheckbox";
+export type { BulkAction, BulkRunSummary } from "./types";
+export { useBulkSelection } from "./useBulkSelection";

--- a/src/web-app/components/Bulk/runBulk.test.ts
+++ b/src/web-app/components/Bulk/runBulk.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { runBulk } from "./runBulk";
+
+describe("runBulk", () => {
+  it("returns empty buckets for no items", async () => {
+    const result = await runBulk([], async () => true);
+    expect(result).toEqual({ ok: [], failed: [] });
+  });
+
+  it("collects every successful item in input order", async () => {
+    const result = await runBulk([1, 2, 3], async () => true);
+    expect(result.ok).toEqual([1, 2, 3]);
+    expect(result.failed).toEqual([]);
+  });
+
+  it("partitions thrown errors and falsy results as failures, preserving order", async () => {
+    const result = await runBulk(["a", "b", "c", "d"], async (item) => {
+      if (item === "b") throw new Error("boom");
+      if (item === "c") return false;
+      return true;
+    });
+    expect(result.ok).toEqual(["a", "d"]);
+    expect(result.failed.map((f) => f.item)).toEqual(["b", "c"]);
+    expect((result.failed[0].error as Error).message).toBe("boom");
+    expect(result.failed[1].error).toBeUndefined();
+  });
+
+  it("never runs more than `concurrency` operations at once", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const items = Array.from({ length: 10 }, (_, i) => i);
+    await runBulk(
+      items,
+      async () => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        inFlight -= 1;
+        return true;
+      },
+      { concurrency: 3 },
+    );
+    expect(maxInFlight).toBe(3);
+  });
+});

--- a/src/web-app/components/Bulk/runBulk.ts
+++ b/src/web-app/components/Bulk/runBulk.ts
@@ -1,0 +1,41 @@
+// components/Bulk/runBulk.ts — pure, bounded-concurrency runner for bulk operations.
+// Runs `run(item)` across items with at most `concurrency` in flight; partitions results into
+// ok/failed (a thrown error OR a falsy resolve counts as failure), preserving input order. No React,
+// no toasts — kept pure so it is directly unit-testable.
+
+import type { BulkRunSummary } from "./types";
+
+export async function runBulk<T>(
+  items: T[],
+  run: (item: T) => Promise<boolean>,
+  opts: { concurrency?: number } = {},
+): Promise<BulkRunSummary<T>> {
+  const concurrency = Math.max(1, opts.concurrency ?? 4);
+  const outcomes: ({ ok: true } | { ok: false; error: unknown })[] = new Array(items.length);
+  let next = 0;
+
+  const worker = async (): Promise<void> => {
+    for (let index = next++; index < items.length; index = next++) {
+      try {
+        const result = await run(items[index]);
+        outcomes[index] = result ? { ok: true } : { ok: false, error: undefined };
+      } catch (error) {
+        outcomes[index] = { ok: false, error };
+      }
+    }
+  };
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()));
+
+  const ok: T[] = [];
+  const failed: { item: T; error: unknown }[] = [];
+  items.forEach((item, index) => {
+    const outcome = outcomes[index];
+    if (outcome.ok) {
+      ok.push(item);
+    } else {
+      failed.push({ item, error: outcome.error });
+    }
+  });
+  return { ok, failed };
+}

--- a/src/web-app/components/Bulk/selection.test.ts
+++ b/src/web-app/components/Bulk/selection.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { headerCheckboxState, pruneIds, toggleId } from "./selection";
+
+describe("toggleId", () => {
+  it("appends an id that is not selected", () => {
+    expect(toggleId(["a", "b"], "c")).toEqual(["a", "b", "c"]);
+  });
+
+  it("removes an id that is already selected, keeping order", () => {
+    expect(toggleId(["a", "b", "c"], "b")).toEqual(["a", "c"]);
+  });
+});
+
+describe("pruneIds", () => {
+  it("drops selected ids that are no longer visible", () => {
+    expect(pruneIds(["a", "b", "c"], ["a", "c"])).toEqual(["a", "c"]);
+  });
+
+  it("returns the same reference when nothing needs pruning (avoids re-render)", () => {
+    const ids = ["a", "b"];
+    expect(pruneIds(ids, ["a", "b", "c"])).toBe(ids);
+  });
+});
+
+describe("headerCheckboxState", () => {
+  it("is unchecked and not indeterminate when nothing is selected", () => {
+    expect(headerCheckboxState(0, 5)).toEqual({ checked: false, indeterminate: false });
+  });
+
+  it("is checked when every visible row is selected", () => {
+    expect(headerCheckboxState(5, 5)).toEqual({ checked: true, indeterminate: false });
+  });
+
+  it("is indeterminate on a partial selection", () => {
+    expect(headerCheckboxState(2, 5)).toEqual({ checked: false, indeterminate: true });
+  });
+
+  it("is unchecked for an empty list", () => {
+    expect(headerCheckboxState(0, 0)).toEqual({ checked: false, indeterminate: false });
+  });
+});

--- a/src/web-app/components/Bulk/selection.ts
+++ b/src/web-app/components/Bulk/selection.ts
@@ -1,0 +1,26 @@
+// components/Bulk/selection.ts — pure set-math behind useBulkSelection (kept separate so it is unit
+// testable without rendering a hook). All functions are referentially stable: pruneIds returns the
+// same array when nothing changes, so selection state doesn't churn React renders on every refresh.
+
+export function toggleId(ids: string[], id: string): string[] {
+  return ids.includes(id) ? ids.filter((it) => it !== id) : [...ids, id];
+}
+
+export function pruneIds(ids: string[], visible: Iterable<string>): string[] {
+  const visibleSet = visible instanceof Set ? visible : new Set(visible);
+  const kept = ids.filter((id) => visibleSet.has(id));
+  return kept.length === ids.length ? ids : kept;
+}
+
+export function headerCheckboxState(
+  selectedCount: number,
+  visibleCount: number,
+): { checked: boolean; indeterminate: boolean } {
+  if (selectedCount === 0 || visibleCount === 0) {
+    return { checked: false, indeterminate: false };
+  }
+  if (selectedCount >= visibleCount) {
+    return { checked: true, indeterminate: false };
+  }
+  return { checked: false, indeterminate: true };
+}

--- a/src/web-app/components/Bulk/summarize.test.ts
+++ b/src/web-app/components/Bulk/summarize.test.ts
@@ -1,0 +1,38 @@
+import { Intent } from "@blueprintjs/core";
+import { describe, expect, it } from "vitest";
+
+import { summarize } from "./summarize";
+
+// Minimal i18next-style interpolation stub so we assert on real message text.
+const t = (key: string, vars?: Record<string, unknown>) =>
+  vars ? key.replace(/\{\{(\w+)\}\}/g, (_, name) => String(vars[name])) : key;
+
+describe("summarize", () => {
+  it("reports success when every item succeeded", () => {
+    const result = summarize("Stop", { ok: [1, 2, 3], failed: [] }, t);
+    expect(result.intent).toBe(Intent.SUCCESS);
+    expect(result.message).toBe("Stop: 3 of 3 succeeded");
+  });
+
+  it("reports a warning on partial failure", () => {
+    const result = summarize("Stop", { ok: [1, 2], failed: [{ item: 3, error: new Error("x") }] }, t);
+    expect(result.intent).toBe(Intent.WARNING);
+    expect(result.message).toBe("Stop: 2 of 3 succeeded");
+  });
+
+  it("reports danger when every item failed", () => {
+    const result = summarize(
+      "Remove",
+      {
+        ok: [],
+        failed: [
+          { item: 1, error: undefined },
+          { item: 2, error: undefined },
+        ],
+      },
+      t,
+    );
+    expect(result.intent).toBe(Intent.DANGER);
+    expect(result.message).toBe("Remove: 0 of 2 succeeded");
+  });
+});

--- a/src/web-app/components/Bulk/summarize.ts
+++ b/src/web-app/components/Bulk/summarize.ts
@@ -1,0 +1,19 @@
+// components/Bulk/summarize.ts — pure headline + intent for a finished bulk run.
+// Conjugation-free message ("Stop: 4 of 4 succeeded") so it stays translation-friendly; the bar can
+// add per-item failure detail on top. Kept pure for unit testing.
+
+import { Intent } from "@blueprintjs/core";
+
+import type { BulkRunSummary } from "./types";
+
+type TFunc = (key: string, vars?: Record<string, unknown>) => string;
+
+export function summarize<T>(label: string, summary: BulkRunSummary<T>, t: TFunc): { intent: Intent; message: string } {
+  const ok = summary.ok.length;
+  const total = ok + summary.failed.length;
+  const intent = summary.failed.length === 0 ? Intent.SUCCESS : ok === 0 ? Intent.DANGER : Intent.WARNING;
+  return {
+    intent,
+    message: t("{{label}}: {{ok}} of {{total}} succeeded", { label, ok, total }),
+  };
+}

--- a/src/web-app/components/Bulk/types.ts
+++ b/src/web-app/components/Bulk/types.ts
@@ -1,0 +1,24 @@
+// components/Bulk/types.ts — shared contracts for the bulk (mass) operations toolkit.
+// A BulkAction operates on the resolved item (not a bare id) so each screen can map to whatever
+// identifier its adapter expects (Container.Id, Volume.Name, Network.name, Secret.ID, …).
+
+import type { Intent } from "@blueprintjs/core";
+import type { IconName } from "@blueprintjs/icons";
+
+export interface BulkAction<T> {
+  key: string;
+  label: string;
+  icon: IconName;
+  intent?: Intent;
+  // Destructive actions (remove) confirm via an Alert before running.
+  destructive?: boolean;
+  // Mirrors the per-row ActionsMenu enable/disable guard for this item.
+  eligible: (item: T) => boolean;
+  // Calls the same adapter/host method the single-row mutation uses; resolves true on success.
+  run: (item: T) => Promise<boolean>;
+}
+
+export interface BulkRunSummary<T> {
+  ok: T[];
+  failed: { item: T; error: unknown }[];
+}

--- a/src/web-app/components/Bulk/useBulkRunner.ts
+++ b/src/web-app/components/Bulk/useBulkRunner.ts
@@ -1,0 +1,33 @@
+// components/Bulk/useBulkRunner.ts — runs one BulkAction over the given items via the pure runBulk
+// pool, then shows a single summary toast (intent + counts from summarize). Returns the summary so the
+// caller can refresh the list once and clear the selection.
+
+import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { Notification } from "@/web-app/Notification";
+import { runBulk } from "./runBulk";
+import { summarize } from "./summarize";
+import type { BulkAction, BulkRunSummary } from "./types";
+
+export function useBulkRunner<T>() {
+  const { t } = useTranslation();
+  const [runningKey, setRunningKey] = useState<string | undefined>();
+
+  const run = useCallback(
+    async (action: BulkAction<T>, items: T[]): Promise<BulkRunSummary<T>> => {
+      setRunningKey(action.key);
+      try {
+        const summary = await runBulk(items, action.run, { concurrency: 4 });
+        const { intent, message } = summarize(action.label, summary, t);
+        Notification.show({ message, intent });
+        return summary;
+      } finally {
+        setRunningKey(undefined);
+      }
+    },
+    [t],
+  );
+
+  return { run, runningKey };
+}

--- a/src/web-app/components/Bulk/useBulkSelection.ts
+++ b/src/web-app/components/Bulk/useBulkSelection.ts
@@ -1,0 +1,68 @@
+// components/Bulk/useBulkSelection.ts — thin React wrapper over the uiStore selection slice + the pure
+// set-math in selection.ts. Selection is always-on (checkboxes are always shown); the action bar appears
+// only when something is selected. `visibleIds` is the current (filtered) id list; the selection is always
+// pruned to it so counts/checkboxes stay correct across refreshes and removals. The math is covered by
+// selection.test.ts and the store by uiStore.test.ts.
+
+import { useCallback, useMemo } from "react";
+
+import { useUIStore } from "@/web-app/stores/uiStore";
+import { headerCheckboxState, pruneIds, toggleId } from "./selection";
+
+const EMPTY: string[] = [];
+
+export function useBulkSelection(scopeId: string, visibleIds: string[]) {
+  const stored = useUIStore((state) => state.selectedRows[scopeId] ?? EMPTY);
+  const setSelectedRows = useUIStore((state) => state.setSelectedRows);
+
+  const selected = useMemo(() => pruneIds(stored, visibleIds), [stored, visibleIds]);
+  const selectedSet = useMemo(() => new Set(selected), [selected]);
+  const headerState = useMemo(
+    () => headerCheckboxState(selected.length, visibleIds.length),
+    [selected.length, visibleIds.length],
+  );
+
+  const isSelected = useCallback((id: string) => selectedSet.has(id), [selectedSet]);
+  const toggle = useCallback(
+    (id: string) => setSelectedRows(scopeId, toggleId(selected, id)),
+    [scopeId, selected, setSelectedRows],
+  );
+  // Toggle a whole subset (e.g. a group): if all are selected, deselect them; otherwise add the missing.
+  const toggleMany = useCallback(
+    (ids: string[]) => {
+      const allSelected = ids.length > 0 && ids.every((id) => selectedSet.has(id));
+      if (allSelected) {
+        const remove = new Set(ids);
+        setSelectedRows(
+          scopeId,
+          selected.filter((id) => !remove.has(id)),
+        );
+      } else {
+        const merged = [...selected];
+        for (const id of ids) {
+          if (!selectedSet.has(id)) {
+            merged.push(id);
+          }
+        }
+        setSelectedRows(scopeId, merged);
+      }
+    },
+    [scopeId, selected, selectedSet, setSelectedRows],
+  );
+  const clear = useCallback(() => setSelectedRows(scopeId, EMPTY), [scopeId, setSelectedRows]);
+  const toggleAll = useCallback(
+    () => setSelectedRows(scopeId, headerState.checked ? EMPTY : [...visibleIds]),
+    [scopeId, headerState.checked, visibleIds, setSelectedRows],
+  );
+
+  return {
+    selectedIds: selectedSet,
+    count: selected.length,
+    isSelected,
+    toggle,
+    toggleMany,
+    clear,
+    toggleAll,
+    headerState,
+  };
+}

--- a/src/web-app/components/NotificationCenter/ActivityRow.tsx
+++ b/src/web-app/components/NotificationCenter/ActivityRow.tsx
@@ -186,14 +186,28 @@ export function ActivityRow({ entry, count = 1 }: { entry: ActivityEntry; count?
               <>
                 <DetailBlock label={t("Equivalent cURL")} value={entry.curl} action={copyAction("curl", entry.curl)} />
                 <DetailBlock label={t("Request body")} value={entry.requestBody} />
+                <DetailBlock label={t("Response body")} value={entry.responseBody} />
                 {entry.error ? <DetailBlock label={t("Error")} value={entry.error} /> : null}
               </>
             ) : null}
             {entry.kind === "cli" ? (
-              <>
-                <DetailBlock label="stdout" value={entry.stdoutPreview} action={copyAction("cmd", entry.commandLine)} />
-                <DetailBlock label="stderr" value={entry.stderrPreview} />
-              </>
+              entry.status === "error" ? (
+                <>
+                  <DetailBlock
+                    label="stdout"
+                    value={entry.stdoutPreview}
+                    action={copyAction("cmd", entry.commandLine)}
+                  />
+                  <DetailBlock label="stderr" value={entry.stderrPreview} />
+                </>
+              ) : (
+                // Successful commands: show the command (copyable) but not the output.
+                <DetailBlock
+                  label={t("Command")}
+                  value={entry.commandLine}
+                  action={copyAction("cmd", entry.commandLine)}
+                />
+              )
             ) : null}
             {entry.kind === "system" ? <DetailBlock label={entry.eventType} value={safeJson(entry.data)} /> : null}
           </div>

--- a/src/web-app/components/NotificationCenter/NotificationBell.tsx
+++ b/src/web-app/components/NotificationCenter/NotificationBell.tsx
@@ -1,11 +1,11 @@
-import { Button, Tag } from "@blueprintjs/core";
+import { Button, Icon } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import { useTranslation } from "react-i18next";
 
 import { selectUnreadCount, useActivityStore } from "@/web-app/stores/activityStore";
 
-// Only toggles store state (the drawer itself is mounted once in NotificationCenterHost).
-// Shows an unread badge for entries since last opened.
+// Only toggles store state (the drawer itself is mounted once in NotificationCenterHost). The bell icon
+// fills white when there are unread entries and stays muted otherwise — the unread signal (no counter).
 export function NotificationBell() {
   const { t } = useTranslation();
   const toggleDrawer = useActivityStore((state) => state.toggleDrawer);
@@ -16,16 +16,11 @@ export function NotificationBell() {
       <Button
         className="NotificationBellButton"
         variant="minimal"
-        icon={IconNames.NOTIFICATIONS}
+        icon={<Icon icon={IconNames.NOTIFICATIONS} color={unread > 0 ? "#ffffff" : "#abb3bf"} />}
         onClick={toggleDrawer}
         title={t("Notifications & activity")}
         aria-label={t("Notifications & activity")}
       />
-      {unread > 0 ? (
-        <Tag className="NotificationBellBadge" round intent="danger">
-          {unread > 99 ? "99+" : unread}
-        </Tag>
-      ) : null}
     </div>
   );
 }

--- a/src/web-app/screens/Container/ManageScreen.css
+++ b/src/web-app/screens/Container/ManageScreen.css
@@ -14,9 +14,10 @@
 [data-table="containers"] tbody td:nth-child(2) {
   text-align: left;
 }
-[data-table="containers"] thead th:last-child,
-[data-table="containers"] tbody td:last-child {
-  width: 1px;
+/* Actions column (second-to-last; selection column is always last) stays shrink-to-fit. */
+[data-table="containers"] thead th:nth-last-child(2),
+[data-table="containers"] tbody tr:not(.AppDataTableGroupRow) td:nth-last-child(2) {
+  width: 1px !important;
 }
 [data-table="containers"] tbody tr {
   position: relative;

--- a/src/web-app/screens/Container/ManageScreen.tsx
+++ b/src/web-app/screens/Container/ManageScreen.tsx
@@ -1,4 +1,14 @@
-import { AnchorButton, Button, ButtonGroup, Code, HTMLTable, Icon, Intent, NonIdealState } from "@blueprintjs/core";
+import {
+  AnchorButton,
+  Button,
+  ButtonGroup,
+  Code,
+  Divider,
+  HTMLTable,
+  Icon,
+  Intent,
+  NonIdealState,
+} from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import dayjs from "dayjs";
 import React, { useCallback, useMemo, useState } from "react";
@@ -8,6 +18,7 @@ import { type Container, ContainerStateList } from "@/env/Types";
 import { AppLabel } from "@/web-app/components/AppLabel";
 import { AppScreenHeader } from "@/web-app/components/AppScreenHeader";
 import { useAppScreenSearch } from "@/web-app/components/AppScreenHooks";
+import { BulkActionsBar, SelectionCheckbox, useBulkSelection } from "@/web-app/components/Bulk";
 import { SortableColumnHeader } from "@/web-app/components/SortableColumnHeader";
 import { sortAlphaNum } from "@/web-app/domain/utils";
 import { useColumnSort } from "@/web-app/hooks/useColumnSort";
@@ -19,6 +30,7 @@ import type { SortSpec } from "@/web-app/stores/sortStore";
 import type { AppScreen, AppScreenProps, ContainerGroup } from "@/web-app/Types";
 import { compareSortValues, type SortSelectors, sortByField } from "@/web-app/utils/comparators";
 import { ActionsMenu } from ".";
+import { useContainerBulkActions } from "./bulkActions";
 import "./ManageScreen.css";
 
 export interface ScreenProps extends AppScreenProps {}
@@ -154,6 +166,10 @@ export const Screen: AppScreen<ScreenProps> = () => {
     () => groupContainers(containers, searchTerm, clientSort),
     [clientSort, containers, searchTerm],
   );
+  const visibleItems = useMemo(() => groups.flatMap((group) => group.Items), [groups]);
+  const visibleIds = useMemo(() => visibleItems.map((item) => item.Id), [visibleItems]);
+  const selection = useBulkSelection(ID, visibleIds);
+  const { actions: bulkActions, getId: bulkGetId, refresh: bulkRefresh } = useContainerBulkActions(connectionId || "");
   const onReload = useCallback(() => {
     if (connectionId) {
       resourceEvents.refresh(connectionId, "containers");
@@ -193,7 +209,24 @@ export const Screen: AppScreen<ScreenProps> = () => {
       <AppScreenHeader
         searchTerm={searchTerm}
         onSearch={onSearchChange}
-        rightContent={<ActionsMenu onReload={onReload} />}
+        rightContent={
+          <>
+            {selection.count > 0 ? (
+              <>
+                <BulkActionsBar
+                  items={visibleItems}
+                  getId={bulkGetId}
+                  selectedIds={selection.selectedIds}
+                  actions={bulkActions}
+                  onClear={selection.clear}
+                  refresh={bulkRefresh}
+                />
+                <Divider />
+              </>
+            ) : null}
+            <ActionsMenu onReload={onReload} />
+          </>
+        }
       />
       <div className="AppScreenContent">
         {groups.length === 0 ? (
@@ -237,12 +270,24 @@ export const Screen: AppScreen<ScreenProps> = () => {
                   <AppLabel iconName={IconNames.CALENDAR} text={t("Created")} />
                 </SortableColumnHeader>
                 <th data-column="Actions">&nbsp;</th>
+                <th data-column="select" className="BulkSelectColumn">
+                  <SelectionCheckbox
+                    checked={selection.headerState.checked}
+                    indeterminate={selection.headerState.indeterminate}
+                    onChange={selection.toggleAll}
+                    title={t("Select all")}
+                  />
+                </th>
               </tr>
             </thead>
             <tbody>
               {groups.map((group) => {
                 const containers = group.Items;
                 const isPartOfGroup = group.Items.length > 1;
+                const groupIds = containers.map((it) => it.Id);
+                const groupSelectedCount = groupIds.reduce((n, id) => n + (selection.isSelected(id) ? 1 : 0), 0);
+                const groupChecked = groupIds.length > 0 && groupSelectedCount === groupIds.length;
+                const groupIndeterminate = groupSelectedCount > 0 && groupSelectedCount < groupIds.length;
                 return (
                   <React.Fragment key={group.Name || group.Id}>
                     {containers.map((container, index) => {
@@ -297,6 +342,14 @@ export const Screen: AppScreen<ScreenProps> = () => {
                                   </li>
                                 </ul>
                               </div>
+                            </td>
+                            <td className="BulkSelectColumn">
+                              <SelectionCheckbox
+                                checked={groupChecked}
+                                indeterminate={groupIndeterminate}
+                                onChange={() => selection.toggleMany(groupIds)}
+                                title={t("Select all in group")}
+                              />
                             </td>
                           </tr>
                         ) : undefined;
@@ -379,6 +432,12 @@ export const Screen: AppScreen<ScreenProps> = () => {
                             <td>{creationDate.format("DD MMM YYYY HH:mm")}</td>
                             <td>
                               <ActionsMenu container={container} withOverlay={containerOverlay === container.Id} />
+                            </td>
+                            <td className="BulkSelectColumn">
+                              <SelectionCheckbox
+                                checked={selection.isSelected(container.Id)}
+                                onChange={() => selection.toggle(container.Id)}
+                              />
                             </td>
                           </tr>
                         );

--- a/src/web-app/screens/Container/bulkActions.test.ts
+++ b/src/web-app/screens/Container/bulkActions.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { ContainerStateList } from "@/env/Types";
+import {
+  containerCanPause,
+  containerCanRemove,
+  containerCanRestart,
+  containerCanStart,
+  containerCanStop,
+} from "./bulkActions";
+
+// Four fixed bulk buttons (Pause / Stop / Start / Restart) are always shown; only their enabled state
+// depends on the item. Pause/Stop/Restart act on running containers; Start acts on anything not running
+// (resumes paused, starts stopped).
+describe("container bulk eligibility", () => {
+  it("pause applies only to running containers", () => {
+    expect(containerCanPause(ContainerStateList.RUNNING)).toBe(true);
+    expect(containerCanPause(ContainerStateList.PAUSED)).toBe(false);
+    expect(containerCanPause(ContainerStateList.EXITED)).toBe(false);
+  });
+
+  it("stop applies only to running containers", () => {
+    expect(containerCanStop(ContainerStateList.RUNNING)).toBe(true);
+    expect(containerCanStop(ContainerStateList.EXITED)).toBe(false);
+  });
+
+  it("restart applies only to running containers", () => {
+    expect(containerCanRestart(ContainerStateList.RUNNING)).toBe(true);
+    expect(containerCanRestart(ContainerStateList.PAUSED)).toBe(false);
+    expect(containerCanRestart(ContainerStateList.EXITED)).toBe(false);
+  });
+
+  it("start applies to anything that is not running", () => {
+    expect(containerCanStart(ContainerStateList.RUNNING)).toBe(false);
+    expect(containerCanStart(ContainerStateList.PAUSED)).toBe(true);
+    expect(containerCanStart(ContainerStateList.EXITED)).toBe(true);
+    expect(containerCanStart(ContainerStateList.STOPPED)).toBe(true);
+  });
+
+  it("remove applies to anything that is not running", () => {
+    expect(containerCanRemove(ContainerStateList.RUNNING)).toBe(false);
+    expect(containerCanRemove(ContainerStateList.EXITED)).toBe(true);
+    expect(containerCanRemove(ContainerStateList.PAUSED)).toBe(true);
+  });
+});

--- a/src/web-app/screens/Container/bulkActions.ts
+++ b/src/web-app/screens/Container/bulkActions.ts
@@ -1,0 +1,82 @@
+// screens/Container/bulkActions.ts — bulk action config for the Containers list. Four fixed lifecycle
+// buttons are always shown — Pause, Stop, Start, Restart — so there is no state-dependent button swapping;
+// only their enabled state varies per item. Start resumes a paused container or starts a stopped one;
+// Pause/Stop/Restart act on running containers. A destructive Remove follows a divider. The pure
+// eligibility predicates mirror the per-row guards and are unit-tested. Wires to the same ContainersAdapter
+// methods the single-row mutations use; one list refresh runs after the batch (by BulkActionsBar).
+
+import { Intent } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
+import { useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import { ContainersAdapter } from "@/container-client/adapters/containers";
+import { type Container, ContainerStateList } from "@/env/Types";
+import type { BulkAction } from "@/web-app/components/Bulk";
+import { resourceEvents } from "@/web-app/stores/resourceEvents";
+import { containerKeys } from "./queries";
+
+export const containerCanPause = (state: ContainerStateList) => state === ContainerStateList.RUNNING;
+export const containerCanStop = (state: ContainerStateList) => state === ContainerStateList.RUNNING;
+export const containerCanRestart = (state: ContainerStateList) => state === ContainerStateList.RUNNING;
+export const containerCanStart = (state: ContainerStateList) => state !== ContainerStateList.RUNNING;
+export const containerCanRemove = (state: ContainerStateList) => state !== ContainerStateList.RUNNING;
+
+export function useContainerBulkActions(connId: string): {
+  actions: BulkAction<Container>[];
+  getId: (item: Container) => string;
+  refresh: () => Promise<void>;
+} {
+  const { t } = useTranslation();
+  const qc = useQueryClient();
+  return useMemo(() => {
+    const adapter = new ContainersAdapter();
+    const refresh = async () => {
+      await resourceEvents.refresh(connId, "containers");
+      qc.invalidateQueries({ queryKey: containerKeys.list(connId) });
+    };
+    const actions: BulkAction<Container>[] = [
+      {
+        key: "pause",
+        label: t("Pause"),
+        icon: IconNames.PAUSE,
+        eligible: (c) => containerCanPause(c.Computed.DecodedState),
+        run: (c) => adapter.pause(c.Id),
+      },
+      {
+        key: "stop",
+        label: t("Stop"),
+        icon: IconNames.STOP,
+        eligible: (c) => containerCanStop(c.Computed.DecodedState),
+        run: (c) => adapter.stop(c.Id),
+      },
+      {
+        // Start = resume a paused container, or start (restart) a stopped one.
+        key: "start",
+        label: t("Start"),
+        icon: IconNames.PLAY,
+        eligible: (c) => containerCanStart(c.Computed.DecodedState),
+        run: (c) =>
+          c.Computed.DecodedState === ContainerStateList.PAUSED ? adapter.unpause(c.Id) : adapter.restart(c.Id),
+      },
+      {
+        key: "restart",
+        label: t("Restart"),
+        icon: IconNames.RESET,
+        eligible: (c) => containerCanRestart(c.Computed.DecodedState),
+        run: (c) => adapter.restart(c.Id),
+      },
+      {
+        key: "remove",
+        label: t("Remove"),
+        icon: IconNames.TRASH,
+        intent: Intent.DANGER,
+        destructive: true,
+        eligible: (c) => containerCanRemove(c.Computed.DecodedState),
+        run: (c) => adapter.remove(c.Id),
+      },
+    ];
+    return { actions, getId: (item: Container) => item.Id, refresh };
+  }, [connId, qc, t]);
+}

--- a/src/web-app/screens/Image/ManageScreen.css
+++ b/src/web-app/screens/Image/ManageScreen.css
@@ -5,7 +5,7 @@
 .AppDataTable[data-table="images"] th:first-child {
   padding-left: 6px;
 }
-.AppDataTable[data-table="images"] th:last-child {
+.AppDataTable[data-table="images"] th:nth-last-child(2) {
   padding-left: initial;
   min-width: 1px;
 }

--- a/src/web-app/screens/Image/ManageScreen.tsx
+++ b/src/web-app/screens/Image/ManageScreen.tsx
@@ -1,4 +1,4 @@
-import { AnchorButton, Code, HTMLTable, Icon, Intent, NonIdealState } from "@blueprintjs/core";
+import { AnchorButton, Code, Divider, HTMLTable, Icon, Intent, NonIdealState } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import { mdiCubeUnfolded } from "@mdi/js";
 import dayjs from "dayjs";
@@ -10,6 +10,7 @@ import type { ContainerImage } from "@/env/Types";
 import { AppLabel } from "@/web-app/components/AppLabel";
 import { AppScreenHeader } from "@/web-app/components/AppScreenHeader";
 import { useAppScreenSearch } from "@/web-app/components/AppScreenHooks";
+import { BulkActionsBar, SelectionCheckbox, useBulkSelection } from "@/web-app/components/Bulk";
 import { SortableColumnHeader } from "@/web-app/components/SortableColumnHeader";
 import { useColumnSort } from "@/web-app/hooks/useColumnSort";
 import { useAppStore } from "@/web-app/stores/appStore";
@@ -19,6 +20,7 @@ import type { AppScreen, AppScreenProps } from "@/web-app/Types";
 import { type SortSelectors, sortByField } from "@/web-app/utils/comparators";
 
 import { ActionsMenu, getImageUrl } from ".";
+import { useImageBulkActions } from "./bulkActions";
 import "./ManageScreen.css";
 
 export const ID = "images";
@@ -61,6 +63,9 @@ export const Screen: AppScreen<ScreenProps> = () => {
     const items = searchTerm ? imageSnapshot.filter(createImageSearchFilter(searchTerm)) : imageSnapshot;
     return sortByField(items, clientSort, imageSortSelectors);
   }, [clientSort, imageSnapshot, searchTerm]);
+  const visibleIds = useMemo(() => images.map((i) => i.Id), [images]);
+  const selection = useBulkSelection(ID, visibleIds);
+  const { actions: bulkActions, getId: bulkGetId, refresh: bulkRefresh } = useImageBulkActions(connectionId || "");
   const onReload = useCallback(() => {
     if (connectionId) {
       resourceEvents.refresh(connectionId, "images");
@@ -72,7 +77,24 @@ export const Screen: AppScreen<ScreenProps> = () => {
       <AppScreenHeader
         searchTerm={searchTerm}
         onSearch={onSearchChange}
-        rightContent={<ActionsMenu withoutStart onReload={onReload} />}
+        rightContent={
+          <>
+            {selection.count > 0 ? (
+              <>
+                <BulkActionsBar
+                  items={images}
+                  getId={bulkGetId}
+                  selectedIds={selection.selectedIds}
+                  actions={bulkActions}
+                  onClear={selection.clear}
+                  refresh={bulkRefresh}
+                />
+                <Divider />
+              </>
+            ) : null}
+            <ActionsMenu withoutStart onReload={onReload} />
+          </>
+        }
       />
       <div className="AppScreenContent">
         {images.length === 0 ? (
@@ -125,6 +147,14 @@ export const Screen: AppScreen<ScreenProps> = () => {
                   <AppLabel iconName={IconNames.CALENDAR} text={t("Created")} />
                 </SortableColumnHeader>
                 <th data-column="Actions">&nbsp;</th>
+                <th data-column="select" className="BulkSelectColumn">
+                  <SelectionCheckbox
+                    checked={selection.headerState.checked}
+                    indeterminate={selection.headerState.indeterminate}
+                    onChange={selection.toggleAll}
+                    title={t("Select all")}
+                  />
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -154,6 +184,12 @@ export const Screen: AppScreen<ScreenProps> = () => {
                     <td>{(dayjs(image.Created * 1000) as any).format("DD MMM YYYY HH:mm")}</td>
                     <td>
                       <ActionsMenu image={image} />
+                    </td>
+                    <td className="BulkSelectColumn">
+                      <SelectionCheckbox
+                        checked={selection.isSelected(image.Id)}
+                        onChange={() => selection.toggle(image.Id)}
+                      />
                     </td>
                   </tr>
                 );

--- a/src/web-app/screens/Image/bulkActions.ts
+++ b/src/web-app/screens/Image/bulkActions.ts
@@ -1,0 +1,40 @@
+// screens/Image/bulkActions.ts — bulk action config for the Images list. Images get a single destructive
+// Remove action. The eligibility predicate is trivially true (any image can be requested for removal); the
+// host rejects images still in use. Wires to the same ImagesAdapter.remove the single-row mutation uses; one
+// list refresh runs after the batch (by BulkActionsBar).
+
+import { Intent } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import { ImagesAdapter } from "@/container-client/adapters/images";
+import type { ContainerImage } from "@/env/Types";
+import type { BulkAction } from "@/web-app/components/Bulk";
+import { resourceEvents } from "@/web-app/stores/resourceEvents";
+
+export function useImageBulkActions(connId: string): {
+  actions: BulkAction<ContainerImage>[];
+  getId: (item: ContainerImage) => string;
+  refresh: () => Promise<void>;
+} {
+  const { t } = useTranslation();
+  return useMemo(() => {
+    const adapter = new ImagesAdapter();
+    const refresh = async () => {
+      await resourceEvents.refresh(connId, "images");
+    };
+    const actions: BulkAction<ContainerImage>[] = [
+      {
+        key: "remove",
+        label: t("Remove"),
+        icon: IconNames.TRASH,
+        intent: Intent.DANGER,
+        destructive: true,
+        eligible: () => true,
+        run: (i) => adapter.remove(i.Id),
+      },
+    ];
+    return { actions, getId: (item: ContainerImage) => item.Id, refresh };
+  }, [connId, t]);
+}

--- a/src/web-app/screens/Machine/ManageScreen.css
+++ b/src/web-app/screens/Machine/ManageScreen.css
@@ -5,9 +5,9 @@
 .AppDataTable[data-table="machines"] th:first-child {
   padding-left: 6px;
 }
-.AppDataTable[data-table="machines"] th:last-child {
-  padding-left: initial;
-  min-width: 1px;
+.AppDataTable[data-table="machines"] th:nth-last-child(2) {
+  padding-left: initial !important;
+  min-width: 1px !important;
 }
 
 .InspectMachineButton {

--- a/src/web-app/screens/Machine/ManageScreen.tsx
+++ b/src/web-app/screens/Machine/ManageScreen.tsx
@@ -1,4 +1,4 @@
-import { AnchorButton, HTMLTable, Intent, NonIdealState } from "@blueprintjs/core";
+import { AnchorButton, Divider, HTMLTable, Intent, NonIdealState } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import dayjs from "dayjs";
 import prettyBytes from "pretty-bytes";
@@ -9,6 +9,7 @@ import type { Connector, PodmanMachine } from "@/env/Types";
 import { AppLabel } from "@/web-app/components/AppLabel";
 import { AppScreenHeader } from "@/web-app/components/AppScreenHeader";
 import { useAppScreenSearch } from "@/web-app/components/AppScreenHooks";
+import { BulkActionsBar, SelectionCheckbox, useBulkSelection } from "@/web-app/components/Bulk";
 import { SortableColumnHeader } from "@/web-app/components/SortableColumnHeader";
 import { useColumnSort } from "@/web-app/hooks/useColumnSort";
 import { useAppStore } from "@/web-app/stores/appStore";
@@ -16,6 +17,7 @@ import type { AppScreen, AppScreenProps } from "@/web-app/Types";
 import { type SortSelectors, sortByField } from "@/web-app/utils/comparators";
 
 import { ActionsMenu } from ".";
+import { useMachineBulkActions } from "./bulkActions";
 import "./ManageScreen.css";
 import { getMachineUrl } from "./Navigation";
 import { useMachinesList } from "./queries";
@@ -61,6 +63,9 @@ export const Screen: AppScreen<ScreenProps> = () => {
     const items = searchTerm ? machineSnapshot.filter(createMachineSearchFilter(searchTerm)) : machineSnapshot;
     return sortByField(items, clientSort, machineSortSelectors);
   }, [clientSort, machineSnapshot, searchTerm]);
+  const visibleIds = useMemo(() => machines.map((m) => m.Name), [machines]);
+  const selection = useBulkSelection(ID, visibleIds);
+  const { actions: bulkActions, getId: bulkGetId, refresh: bulkRefresh } = useMachineBulkActions(connectionId || "");
   const onReload = useCallback(() => {
     machinesQuery.refetch();
   }, [machinesQuery]);
@@ -71,7 +76,24 @@ export const Screen: AppScreen<ScreenProps> = () => {
         searchTerm={searchTerm}
         onSearch={onSearchChange}
         titleIcon={IconNames.HEAT_GRID}
-        rightContent={<ActionsMenu onReload={onReload} />}
+        rightContent={
+          <>
+            {selection.count > 0 ? (
+              <>
+                <BulkActionsBar
+                  items={machines}
+                  getId={bulkGetId}
+                  selectedIds={selection.selectedIds}
+                  actions={bulkActions}
+                  onClear={selection.clear}
+                  refresh={bulkRefresh}
+                />
+                <Divider />
+              </>
+            ) : null}
+            <ActionsMenu onReload={onReload} />
+          </>
+        }
       />
       <div className="AppScreenContent">
         {machines.length === 0 ? (
@@ -140,6 +162,14 @@ export const Screen: AppScreen<ScreenProps> = () => {
                   <AppLabel iconName={IconNames.CALENDAR} text={t("Created")} />
                 </SortableColumnHeader>
                 <th data-column="Actions">&nbsp;</th>
+                <th data-column="select" className="BulkSelectColumn">
+                  <SelectionCheckbox
+                    checked={selection.headerState.checked}
+                    indeterminate={selection.headerState.indeterminate}
+                    onChange={selection.toggleAll}
+                    title={t("Select all")}
+                  />
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -176,6 +206,12 @@ export const Screen: AppScreen<ScreenProps> = () => {
                     <td>{dayjs(machine.Created).format("DD MMM YYYY HH:mm")}</td>
                     <td>
                       <ActionsMenu withoutCreate machine={machine} />
+                    </td>
+                    <td className="BulkSelectColumn">
+                      <SelectionCheckbox
+                        checked={selection.isSelected(machine.Name)}
+                        onChange={() => selection.toggle(machine.Name)}
+                      />
                     </td>
                   </tr>
                 );

--- a/src/web-app/screens/Machine/bulkActions.test.ts
+++ b/src/web-app/screens/Machine/bulkActions.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import type { PodmanMachine } from "@/env/Types";
+import { machineCanStop } from "./bulkActions";
+
+// Stop is the only state-dependent bulk button for machines; it applies only to running machines.
+// Restart/Remove are always enabled. Running is detected via a "running" State or the Running flag,
+// mirroring Machine/ActionsMenu.tsx.
+describe("machine bulk eligibility", () => {
+  it("stop applies only to running machines", () => {
+    expect(machineCanStop({ Running: true } as PodmanMachine)).toBe(true);
+    expect(machineCanStop({ State: "running" } as unknown as PodmanMachine)).toBe(true);
+    expect(machineCanStop({ Running: false } as PodmanMachine)).toBe(false);
+    expect(machineCanStop({ State: "stopped" } as unknown as PodmanMachine)).toBe(false);
+    expect(machineCanStop({} as PodmanMachine)).toBe(false);
+  });
+});

--- a/src/web-app/screens/Machine/bulkActions.ts
+++ b/src/web-app/screens/Machine/bulkActions.ts
@@ -1,0 +1,69 @@
+// screens/Machine/bulkActions.ts — bulk action config for the Machines list. Three fixed lifecycle
+// buttons are shown — Stop, Restart, Remove (no pause/start for machines) — so there is no
+// state-dependent button swapping; only their enabled state varies per item. Stop acts on running
+// machines; Restart and Remove are always enabled (mirroring the per-row ActionsMenu guards). A
+// destructive Remove follows. The pure eligibility predicates mirror the per-row guards and are
+// unit-tested. Wires to the same host-client methods the single-row mutations use; one list refresh
+// runs after the batch (by BulkActionsBar) via TanStack-Query invalidation.
+
+import { Intent } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
+import { useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import { getActiveHostClient } from "@/container-client/adapters/shared";
+import type { PodmanMachine } from "@/env/Types";
+import type { BulkAction } from "@/web-app/components/Bulk";
+import { machineKeys } from "./queries";
+
+// Mirrors Machine/ActionsMenu.tsx: a machine is running when its State is "running" or the Running flag is set.
+export const machineIsRunning = (machine: PodmanMachine) =>
+  ((machine as any)?.State || "").toLowerCase() === "running" || !!(machine as any)?.Running;
+
+export const machineCanStop = (machine: PodmanMachine) => machineIsRunning(machine);
+// Restart mirrors the per-row guard, which is always enabled (it doubles as Start when stopped).
+export const machineCanRestart = (_machine: PodmanMachine) => true;
+// Remove mirrors the per-row guard, which is always enabled.
+export const machineCanRemove = (_machine: PodmanMachine) => true;
+
+export function useMachineBulkActions(connId: string): {
+  actions: BulkAction<PodmanMachine>[];
+  getId: (item: PodmanMachine) => string;
+  refresh: () => Promise<void>;
+} {
+  const { t } = useTranslation();
+  const qc = useQueryClient();
+  return useMemo(() => {
+    const host = getActiveHostClient();
+    const refresh = async () => {
+      qc.invalidateQueries({ queryKey: machineKeys.list(connId) });
+    };
+    const actions: BulkAction<PodmanMachine>[] = [
+      {
+        key: "stop",
+        label: t("Stop"),
+        icon: IconNames.STOP,
+        eligible: (m) => machineCanStop(m),
+        run: (m) => host.stopPodmanMachine(m.Name),
+      },
+      {
+        key: "restart",
+        label: t("Restart"),
+        icon: IconNames.RESET,
+        eligible: (m) => machineCanRestart(m),
+        run: (m) => host.restartPodmanMachine(m.Name),
+      },
+      {
+        key: "remove",
+        label: t("Remove"),
+        icon: IconNames.TRASH,
+        intent: Intent.DANGER,
+        destructive: true,
+        eligible: (m) => machineCanRemove(m),
+        run: (m) => host.removePodmanMachine(m.Name),
+      },
+    ];
+    return { actions, getId: (item: PodmanMachine) => item.Name, refresh };
+  }, [connId, qc, t]);
+}

--- a/src/web-app/screens/Network/ManageScreen.css
+++ b/src/web-app/screens/Network/ManageScreen.css
@@ -5,7 +5,7 @@
 .AppDataTable[data-table="networks"] th:first-child {
   padding-left: 6px;
 }
-.AppDataTable[data-table="networks"] th:last-child {
+.AppDataTable[data-table="networks"] th:nth-last-child(2) {
   padding-left: initial;
   min-width: 1px;
 }

--- a/src/web-app/screens/Network/ManageScreen.tsx
+++ b/src/web-app/screens/Network/ManageScreen.tsx
@@ -1,4 +1,4 @@
-import { AnchorButton, Code, HTMLTable, Intent, NonIdealState } from "@blueprintjs/core";
+import { AnchorButton, Code, Divider, HTMLTable, Intent, NonIdealState } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import { mdiDns, mdiEthernet, mdiInfinity, mdiNetwork, mdiScrewdriver } from "@mdi/js";
 import * as ReactIcon from "@mdi/react";
@@ -10,6 +10,7 @@ import type { Network } from "@/env/Types";
 import { AppLabel } from "@/web-app/components/AppLabel";
 import { AppScreenHeader } from "@/web-app/components/AppScreenHeader";
 import { useAppScreenSearch } from "@/web-app/components/AppScreenHooks";
+import { BulkActionsBar, SelectionCheckbox, useBulkSelection } from "@/web-app/components/Bulk";
 import { SortableColumnHeader } from "@/web-app/components/SortableColumnHeader";
 import { sortAlphaNum } from "@/web-app/domain/utils";
 import { useColumnSort } from "@/web-app/hooks/useColumnSort";
@@ -20,6 +21,7 @@ import type { AppScreen, AppScreenProps } from "@/web-app/Types";
 import { type SortSelectors, sortByField } from "@/web-app/utils/comparators";
 
 import { ActionsMenu } from ".";
+import { useNetworkBulkActions } from "./bulkActions";
 import "./ManageScreen.css";
 import { getNetworkUrl } from "./Navigation";
 
@@ -66,6 +68,9 @@ export const Screen: AppScreen<ScreenProps> = () => {
       ? sortByField(items, clientSort, networkSortSelectors)
       : [...items].sort((a, b) => sortAlphaNum(a.name, b.name));
   }, [clientSort, networkSnapshot, searchTerm]);
+  const visibleIds = useMemo(() => (networks || []).map((n) => n.id), [networks]);
+  const selection = useBulkSelection(ID, visibleIds);
+  const { actions: bulkActions, getId: bulkGetId, refresh: bulkRefresh } = useNetworkBulkActions(connectionId || "");
   const onReload = useCallback(() => {
     if (connectionId) {
       resourceEvents.refresh(connectionId, "networks");
@@ -78,7 +83,24 @@ export const Screen: AppScreen<ScreenProps> = () => {
         searchTerm={searchTerm}
         onSearch={onSearchChange}
         titleIcon={IconNames.HEAT_GRID}
-        rightContent={<ActionsMenu onReload={onReload} />}
+        rightContent={
+          <>
+            {selection.count > 0 ? (
+              <>
+                <BulkActionsBar
+                  items={networks || []}
+                  getId={bulkGetId}
+                  selectedIds={selection.selectedIds}
+                  actions={bulkActions}
+                  onClear={selection.clear}
+                  refresh={bulkRefresh}
+                />
+                <Divider />
+              </>
+            ) : null}
+            <ActionsMenu onReload={onReload} />
+          </>
+        }
       />
       <div className="AppScreenContent">
         {networks.length === 0 ? (
@@ -134,6 +156,14 @@ export const Screen: AppScreen<ScreenProps> = () => {
                   <AppLabel iconName={IconNames.CALENDAR} text={t("Created")} />
                 </SortableColumnHeader>
                 <th data-column="Actions">&nbsp;</th>
+                <th data-column="select" className="BulkSelectColumn">
+                  <SelectionCheckbox
+                    checked={selection.headerState.checked}
+                    indeterminate={selection.headerState.indeterminate}
+                    onChange={selection.toggleAll}
+                    title={t("Select all")}
+                  />
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -166,6 +196,12 @@ export const Screen: AppScreen<ScreenProps> = () => {
                     <td>{creationDate.format("DD MMM YYYY HH:mm")}</td>
                     <td>
                       <ActionsMenu withoutCreate network={network} />
+                    </td>
+                    <td className="BulkSelectColumn">
+                      <SelectionCheckbox
+                        checked={selection.isSelected(network.id)}
+                        onChange={() => selection.toggle(network.id)}
+                      />
                     </td>
                   </tr>
                 );

--- a/src/web-app/screens/Network/bulkActions.ts
+++ b/src/web-app/screens/Network/bulkActions.ts
@@ -1,0 +1,41 @@
+// screens/Network/bulkActions.ts — bulk action config for the Networks list. Networks expose a single
+// destructive Remove button. The selection key is the network id (the row's unique key), but the remove
+// adapter takes the network name — mirroring the per-row ActionsMenu, which passes network.name to remove.
+// Wires to the same NetworksAdapter.remove the single-row mutation uses; one list refresh runs after the
+// batch (by BulkActionsBar).
+
+import { Intent } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import { NetworksAdapter } from "@/container-client/adapters/networks";
+import type { Network } from "@/env/Types";
+import type { BulkAction } from "@/web-app/components/Bulk";
+import { resourceEvents } from "@/web-app/stores/resourceEvents";
+
+export function useNetworkBulkActions(connId: string): {
+  actions: BulkAction<Network>[];
+  getId: (item: Network) => string;
+  refresh: () => Promise<void>;
+} {
+  const { t } = useTranslation();
+  return useMemo(() => {
+    const adapter = new NetworksAdapter();
+    const refresh = async () => {
+      await resourceEvents.refresh(connId, "networks");
+    };
+    const actions: BulkAction<Network>[] = [
+      {
+        key: "remove",
+        label: t("Remove"),
+        icon: IconNames.TRASH,
+        intent: Intent.DANGER,
+        destructive: true,
+        eligible: () => true,
+        run: (n) => adapter.remove(n.name),
+      },
+    ];
+    return { actions, getId: (item: Network) => item.id, refresh };
+  }, [connId, t]);
+}

--- a/src/web-app/screens/Pod/ManageScreen.css
+++ b/src/web-app/screens/Pod/ManageScreen.css
@@ -5,9 +5,12 @@
 .AppDataTable[data-table="pods"] th:first-child {
   padding-left: 6px;
 }
-.AppDataTable[data-table="pods"] th:last-child {
+/* Actions column (second-to-last; the selection column is always last) stays shrink-to-fit. */
+.AppDataTable[data-table="pods"] th:nth-last-child(2),
+.AppDataTable[data-table="pods"] tbody td:nth-last-child(2) {
   padding-left: initial;
   min-width: 1px;
+  width: 1px !important;
 }
 
 [data-table="pods"] .PodDetailsButton {

--- a/src/web-app/screens/Pod/ManageScreen.tsx
+++ b/src/web-app/screens/Pod/ManageScreen.tsx
@@ -1,4 +1,4 @@
-import { AnchorButton, Code, HTMLTable, Intent, NonIdealState } from "@blueprintjs/core";
+import { AnchorButton, Code, Divider, HTMLTable, Intent, NonIdealState } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import dayjs from "dayjs";
 import { useCallback, useMemo } from "react";
@@ -8,6 +8,7 @@ import type { Connector, Pod } from "@/env/Types";
 import { AppLabel } from "@/web-app/components/AppLabel";
 import { AppScreenHeader } from "@/web-app/components/AppScreenHeader";
 import { useAppScreenSearch } from "@/web-app/components/AppScreenHooks";
+import { BulkActionsBar, SelectionCheckbox, useBulkSelection } from "@/web-app/components/Bulk";
 import { SortableColumnHeader } from "@/web-app/components/SortableColumnHeader";
 import { sortAlphaNum } from "@/web-app/domain/utils";
 import { useColumnSort } from "@/web-app/hooks/useColumnSort";
@@ -19,6 +20,7 @@ import type { AppScreen, AppScreenProps } from "@/web-app/Types";
 import { type SortSelectors, sortByField } from "@/web-app/utils/comparators";
 
 import { ItemActionsMenu, ListActionsMenu } from ".";
+import { usePodBulkActions } from "./bulkActions";
 import "./ManageScreen.css";
 
 export interface ScreenProps extends AppScreenProps {}
@@ -61,6 +63,9 @@ export const Screen: AppScreen<ScreenProps> = () => {
       ? sortByField(items, clientSort, podSortSelectors)
       : [...items].sort((a, b) => sortAlphaNum(a.Name, b.Name));
   }, [clientSort, podSnapshot, searchTerm]);
+  const visibleIds = useMemo(() => pods.map((p) => p.Id), [pods]);
+  const selection = useBulkSelection(ID, visibleIds);
+  const { actions: bulkActions, getId: bulkGetId, refresh: bulkRefresh } = usePodBulkActions(connectionId || "");
   const onReload = useCallback(() => {
     if (connectionId) {
       resourceEvents.refreshMany(connectionId, ["pods", "containers"]);
@@ -73,7 +78,24 @@ export const Screen: AppScreen<ScreenProps> = () => {
         searchTerm={searchTerm}
         onSearch={onSearchChange}
         titleIcon={IconNames.KEY}
-        rightContent={<ListActionsMenu onReload={onReload} />}
+        rightContent={
+          <>
+            {selection.count > 0 ? (
+              <>
+                <BulkActionsBar
+                  items={pods}
+                  getId={bulkGetId}
+                  selectedIds={selection.selectedIds}
+                  actions={bulkActions}
+                  onClear={selection.clear}
+                  refresh={bulkRefresh}
+                />
+                <Divider />
+              </>
+            ) : null}
+            <ListActionsMenu onReload={onReload} />
+          </>
+        }
       />
       <div className="AppScreenContent">
         {pods.length === 0 ? (
@@ -120,6 +142,14 @@ export const Screen: AppScreen<ScreenProps> = () => {
                   <AppLabel iconName={IconNames.CALENDAR} text={t("Created")} />
                 </SortableColumnHeader>
                 <th data-column="Actions">&nbsp;</th>
+                <th data-column="select" className="BulkSelectColumn">
+                  <SelectionCheckbox
+                    checked={selection.headerState.checked}
+                    indeterminate={selection.headerState.indeterminate}
+                    onChange={selection.toggleAll}
+                    title={t("Select all")}
+                  />
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -153,6 +183,12 @@ export const Screen: AppScreen<ScreenProps> = () => {
                     <td>{creationDate.format("DD MMM YYYY HH:mm")}</td>
                     <td>
                       <ItemActionsMenu pod={pod} />
+                    </td>
+                    <td className="BulkSelectColumn">
+                      <SelectionCheckbox
+                        checked={selection.isSelected(pod.Id)}
+                        onChange={() => selection.toggle(pod.Id)}
+                      />
                     </td>
                   </tr>
                 );

--- a/src/web-app/screens/Pod/bulkActions.test.ts
+++ b/src/web-app/screens/Pod/bulkActions.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { PodStatusList } from "@/env/Types";
+import { podCanPause, podCanRestart, podCanStart, podCanStop } from "./bulkActions";
+
+// Four fixed bulk buttons (Pause / Stop / Start / Restart) are always shown; only their enabled state
+// depends on the item. Pause/Stop/Restart act on running pods; Start acts on anything not running
+// (resumes paused, starts/restarts the rest).
+describe("pod bulk eligibility", () => {
+  it("pause applies only to running pods", () => {
+    expect(podCanPause(PodStatusList.RUNNING)).toBe(true);
+    expect(podCanPause(PodStatusList.PAUSED)).toBe(false);
+    expect(podCanPause(PodStatusList.EXITED)).toBe(false);
+  });
+
+  it("stop applies only to running pods", () => {
+    expect(podCanStop(PodStatusList.RUNNING)).toBe(true);
+    expect(podCanStop(PodStatusList.EXITED)).toBe(false);
+  });
+
+  it("restart applies only to running pods", () => {
+    expect(podCanRestart(PodStatusList.RUNNING)).toBe(true);
+    expect(podCanRestart(PodStatusList.PAUSED)).toBe(false);
+    expect(podCanRestart(PodStatusList.EXITED)).toBe(false);
+  });
+
+  it("start applies to anything that is not running", () => {
+    expect(podCanStart(PodStatusList.RUNNING)).toBe(false);
+    expect(podCanStart(PodStatusList.PAUSED)).toBe(true);
+    expect(podCanStart(PodStatusList.EXITED)).toBe(true);
+    expect(podCanStart(PodStatusList.STOPPED)).toBe(true);
+  });
+});

--- a/src/web-app/screens/Pod/bulkActions.ts
+++ b/src/web-app/screens/Pod/bulkActions.ts
@@ -1,0 +1,77 @@
+// screens/Pod/bulkActions.ts — bulk action config for the Pods list. Four fixed lifecycle buttons are
+// always shown — Pause, Stop, Start, Restart — so there is no state-dependent button swapping; only their
+// enabled state varies per item. Start resumes a paused pod or restarts/starts a non-running one;
+// Pause/Stop/Restart act on running pods. A destructive Remove follows (no state guard — it mirrors the
+// per-row ConfirmMenu, which only disables while a remove is in flight). The pure eligibility predicates
+// mirror the per-row guards and are unit-tested. Wires to the same PodsAdapter methods the single-row
+// mutations use; one list refresh runs after the batch (by BulkActionsBar).
+
+import { Intent } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import { PodsAdapter } from "@/container-client/adapters/pods";
+import { type Pod, PodStatusList } from "@/env/Types";
+import type { BulkAction } from "@/web-app/components/Bulk";
+import { resourceEvents } from "@/web-app/stores/resourceEvents";
+
+export const podCanPause = (status: PodStatusList) => status === PodStatusList.RUNNING;
+export const podCanStop = (status: PodStatusList) => status === PodStatusList.RUNNING;
+export const podCanRestart = (status: PodStatusList) => status === PodStatusList.RUNNING;
+export const podCanStart = (status: PodStatusList) => status !== PodStatusList.RUNNING;
+
+export function usePodBulkActions(connId: string): {
+  actions: BulkAction<Pod>[];
+  getId: (item: Pod) => string;
+  refresh: () => Promise<void>;
+} {
+  const { t } = useTranslation();
+  return useMemo(() => {
+    const adapter = new PodsAdapter();
+    const refresh = async () => {
+      await resourceEvents.refreshMany(connId, ["pods", "containers"]);
+    };
+    const actions: BulkAction<Pod>[] = [
+      {
+        key: "pause",
+        label: t("Pause"),
+        icon: IconNames.PAUSE,
+        eligible: (p) => podCanPause(p.Status),
+        run: (p) => adapter.pause(p.Id),
+      },
+      {
+        key: "stop",
+        label: t("Stop"),
+        icon: IconNames.STOP,
+        eligible: (p) => podCanStop(p.Status),
+        run: (p) => adapter.stop(p.Id),
+      },
+      {
+        // Start = resume a paused pod, or start (restart) a non-running one.
+        key: "start",
+        label: t("Start"),
+        icon: IconNames.PLAY,
+        eligible: (p) => podCanStart(p.Status),
+        run: (p) => (p.Status === PodStatusList.PAUSED ? adapter.unpause(p.Id) : adapter.restart(p.Id)),
+      },
+      {
+        key: "restart",
+        label: t("Restart"),
+        icon: IconNames.RESET,
+        eligible: (p) => podCanRestart(p.Status),
+        run: (p) => adapter.restart(p.Id),
+      },
+      {
+        key: "remove",
+        label: t("Remove"),
+        icon: IconNames.TRASH,
+        intent: Intent.DANGER,
+        destructive: true,
+        eligible: () => true,
+        run: (p) => adapter.remove(p.Id),
+      },
+    ];
+    return { actions, getId: (item: Pod) => item.Id, refresh };
+  }, [connId, t]);
+}

--- a/src/web-app/screens/Secret/ManageScreen.css
+++ b/src/web-app/screens/Secret/ManageScreen.css
@@ -5,7 +5,7 @@
 .AppDataTable[data-table="secrets"] th:first-child {
   padding-left: 6px;
 }
-.AppDataTable[data-table="secrets"] th:last-child {
+.AppDataTable[data-table="secrets"] th:nth-last-child(2) {
   padding-left: initial;
   min-width: 1px;
 }

--- a/src/web-app/screens/Secret/ManageScreen.tsx
+++ b/src/web-app/screens/Secret/ManageScreen.tsx
@@ -1,4 +1,4 @@
-import { AnchorButton, Code, HTMLTable, Intent, NonIdealState } from "@blueprintjs/core";
+import { AnchorButton, Code, Divider, HTMLTable, Intent, NonIdealState } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import dayjs from "dayjs";
 import { useCallback, useMemo } from "react";
@@ -8,6 +8,7 @@ import type { Connector, Secret } from "@/env/Types";
 import { AppLabel } from "@/web-app/components/AppLabel";
 import { AppScreenHeader } from "@/web-app/components/AppScreenHeader";
 import { useAppScreenSearch } from "@/web-app/components/AppScreenHooks";
+import { BulkActionsBar, SelectionCheckbox, useBulkSelection } from "@/web-app/components/Bulk";
 import { SortableColumnHeader } from "@/web-app/components/SortableColumnHeader";
 import { sortAlphaNum } from "@/web-app/domain/utils";
 import { useColumnSort } from "@/web-app/hooks/useColumnSort";
@@ -18,6 +19,7 @@ import type { AppScreen, AppScreenProps } from "@/web-app/Types";
 import { type SortSelectors, sortByField } from "@/web-app/utils/comparators";
 
 import { SecretActionsMenu } from ".";
+import { useSecretBulkActions } from "./bulkActions";
 import "./ManageScreen.css";
 import { getSecretUrl } from "./Navigation";
 
@@ -62,6 +64,9 @@ export const Screen: AppScreen<ScreenProps> = () => {
       ? sortByField(items, clientSort, secretSortSelectors)
       : [...items].sort((a, b) => sortAlphaNum(a.Spec?.Name || "", b.Spec?.Name || ""));
   }, [clientSort, secretSnapshot, searchTerm]);
+  const visibleIds = useMemo(() => secrets.map((s) => s.ID), [secrets]);
+  const selection = useBulkSelection(ID, visibleIds);
+  const { actions: bulkActions, getId: bulkGetId, refresh: bulkRefresh } = useSecretBulkActions(connectionId || "");
   const onReload = useCallback(() => {
     if (connectionId) {
       resourceEvents.refresh(connectionId, "secrets");
@@ -74,7 +79,24 @@ export const Screen: AppScreen<ScreenProps> = () => {
         searchTerm={searchTerm}
         onSearch={onSearchChange}
         titleIcon={IconNames.KEY}
-        rightContent={<SecretActionsMenu onReload={onReload} />}
+        rightContent={
+          <>
+            {selection.count > 0 ? (
+              <>
+                <BulkActionsBar
+                  items={secrets}
+                  getId={bulkGetId}
+                  selectedIds={selection.selectedIds}
+                  actions={bulkActions}
+                  onClear={selection.clear}
+                  refresh={bulkRefresh}
+                />
+                <Divider />
+              </>
+            ) : null}
+            <SecretActionsMenu onReload={onReload} />
+          </>
+        }
       />
       <div className="AppScreenContent">
         {secrets.length === 0 ? (
@@ -108,6 +130,14 @@ export const Screen: AppScreen<ScreenProps> = () => {
                   <AppLabel iconName={IconNames.CALENDAR} text={t("Created")} />
                 </SortableColumnHeader>
                 <th data-column="Actions">&nbsp;</th>
+                <th data-column="select" className="BulkSelectColumn">
+                  <SelectionCheckbox
+                    checked={selection.headerState.checked}
+                    indeterminate={selection.headerState.indeterminate}
+                    onChange={selection.toggleAll}
+                    title={t("Select all")}
+                  />
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -132,6 +162,12 @@ export const Screen: AppScreen<ScreenProps> = () => {
                     <td>{(dayjs(secret.CreatedAt) as any).fromNow()}</td>
                     <td>
                       <SecretActionsMenu withoutCreate secret={secret} />
+                    </td>
+                    <td className="BulkSelectColumn">
+                      <SelectionCheckbox
+                        checked={selection.isSelected(secret.ID)}
+                        onChange={() => selection.toggle(secret.ID)}
+                      />
                     </td>
                   </tr>
                 );

--- a/src/web-app/screens/Secret/bulkActions.ts
+++ b/src/web-app/screens/Secret/bulkActions.ts
@@ -1,0 +1,40 @@
+// screens/Secret/bulkActions.ts — bulk action config for the Secrets list. Secrets support a single
+// destructive Remove; there is no lifecycle state to gate on, so the action is always eligible. Wires to
+// the same SecretsAdapter method the single-row mutation uses; one list refresh runs after the batch
+// (by BulkActionsBar).
+
+import { Intent } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import { SecretsAdapter } from "@/container-client/adapters/secrets";
+import type { Secret } from "@/env/Types";
+import type { BulkAction } from "@/web-app/components/Bulk";
+import { resourceEvents } from "@/web-app/stores/resourceEvents";
+
+export function useSecretBulkActions(connId: string): {
+  actions: BulkAction<Secret>[];
+  getId: (item: Secret) => string;
+  refresh: () => Promise<void>;
+} {
+  const { t } = useTranslation();
+  return useMemo(() => {
+    const adapter = new SecretsAdapter();
+    const refresh = async () => {
+      await resourceEvents.refresh(connId, "secrets");
+    };
+    const actions: BulkAction<Secret>[] = [
+      {
+        key: "remove",
+        label: t("Remove"),
+        icon: IconNames.TRASH,
+        intent: Intent.DANGER,
+        destructive: true,
+        eligible: () => true,
+        run: (s) => adapter.remove(s.ID),
+      },
+    ];
+    return { actions, getId: (item: Secret) => item.ID, refresh };
+  }, [connId, t]);
+}

--- a/src/web-app/screens/Volume/ManageScreen.css
+++ b/src/web-app/screens/Volume/ManageScreen.css
@@ -5,7 +5,7 @@
 .AppDataTable[data-table="volumes"] th:first-child {
   padding-left: 6px;
 }
-.AppDataTable[data-table="volumes"] th:last-child {
+.AppDataTable[data-table="volumes"] th:nth-last-child(2) {
   padding-left: initial;
   min-width: 1px;
 }

--- a/src/web-app/screens/Volume/ManageScreen.tsx
+++ b/src/web-app/screens/Volume/ManageScreen.tsx
@@ -1,4 +1,4 @@
-import { AnchorButton, HTMLTable, Intent, NonIdealState } from "@blueprintjs/core";
+import { AnchorButton, Divider, HTMLTable, Intent, NonIdealState } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import { mdiScrewdriver } from "@mdi/js";
 import dayjs from "dayjs";
@@ -9,6 +9,7 @@ import type { Volume } from "@/env/Types";
 import { AppLabel } from "@/web-app/components/AppLabel";
 import { AppScreenHeader } from "@/web-app/components/AppScreenHeader";
 import { useAppScreenSearch } from "@/web-app/components/AppScreenHooks";
+import { BulkActionsBar, SelectionCheckbox, useBulkSelection } from "@/web-app/components/Bulk";
 import { SortableColumnHeader } from "@/web-app/components/SortableColumnHeader";
 import { sortAlphaNum } from "@/web-app/domain/utils";
 import { useColumnSort } from "@/web-app/hooks/useColumnSort";
@@ -18,6 +19,7 @@ import { useResourceStore } from "@/web-app/stores/resourceStore";
 import type { AppScreen, AppScreenProps } from "@/web-app/Types";
 import { type SortSelectors, sortByField } from "@/web-app/utils/comparators";
 import { VolumeActionsMenu } from ".";
+import { useVolumeBulkActions } from "./bulkActions";
 import { getVolumeUrl } from "./Navigation";
 import "./ManageScreen.css";
 
@@ -59,6 +61,9 @@ export const Screen: AppScreen<ScreenProps> = () => {
       ? sortByField(items, clientSort, volumeSortSelectors)
       : [...items].sort((a, b) => sortAlphaNum(a.Name, b.Name));
   }, [clientSort, volumeSnapshot, searchTerm]);
+  const visibleIds = useMemo(() => volumes.map((v) => v.Name), [volumes]);
+  const selection = useBulkSelection(ID, visibleIds);
+  const { actions: bulkActions, getId: bulkGetId, refresh: bulkRefresh } = useVolumeBulkActions(connectionId || "");
   const onReload = useCallback(() => {
     if (connectionId) {
       resourceEvents.refresh(connectionId, "volumes");
@@ -71,7 +76,24 @@ export const Screen: AppScreen<ScreenProps> = () => {
         searchTerm={searchTerm}
         onSearch={onSearchChange}
         titleIcon={IconNames.DATABASE}
-        rightContent={<VolumeActionsMenu onReload={onReload} />}
+        rightContent={
+          <>
+            {selection.count > 0 ? (
+              <>
+                <BulkActionsBar
+                  items={volumes}
+                  getId={bulkGetId}
+                  selectedIds={selection.selectedIds}
+                  actions={bulkActions}
+                  onClear={selection.clear}
+                  refresh={bulkRefresh}
+                />
+                <Divider />
+              </>
+            ) : null}
+            <VolumeActionsMenu onReload={onReload} />
+          </>
+        }
       />
       <div className="AppScreenContent">
         {volumes.length === 0 ? (
@@ -102,6 +124,14 @@ export const Screen: AppScreen<ScreenProps> = () => {
                   <AppLabel iconName={IconNames.CALENDAR} text={t("Created")} />
                 </SortableColumnHeader>
                 <th data-column="Actions">&nbsp;</th>
+                <th data-column="select" className="BulkSelectColumn">
+                  <SelectionCheckbox
+                    checked={selection.headerState.checked}
+                    indeterminate={selection.headerState.indeterminate}
+                    onChange={selection.toggleAll}
+                    title={t("Select all")}
+                  />
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -124,6 +154,12 @@ export const Screen: AppScreen<ScreenProps> = () => {
                     <td>{(dayjs(volume.CreatedAt) as any).fromNow()}</td>
                     <td>
                       <VolumeActionsMenu withoutCreate volume={volume} />
+                    </td>
+                    <td className="BulkSelectColumn">
+                      <SelectionCheckbox
+                        checked={selection.isSelected(volume.Name)}
+                        onChange={() => selection.toggle(volume.Name)}
+                      />
                     </td>
                   </tr>
                 );

--- a/src/web-app/screens/Volume/bulkActions.ts
+++ b/src/web-app/screens/Volume/bulkActions.ts
@@ -1,0 +1,40 @@
+// screens/Volume/bulkActions.ts — bulk action config for the Volumes list. Volumes only support a single
+// destructive Remove action; there are no lifecycle states, so the eligibility predicate is always true.
+// Volumes are keyed by Name (not Id). Wires to the same VolumesAdapter.remove method the single-row mutation
+// uses; one list refresh runs after the batch (by BulkActionsBar).
+
+import { Intent } from "@blueprintjs/core";
+import { IconNames } from "@blueprintjs/icons";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import { VolumesAdapter } from "@/container-client/adapters/volumes";
+import type { Volume } from "@/env/Types";
+import type { BulkAction } from "@/web-app/components/Bulk";
+import { resourceEvents } from "@/web-app/stores/resourceEvents";
+
+export function useVolumeBulkActions(connId: string): {
+  actions: BulkAction<Volume>[];
+  getId: (item: Volume) => string;
+  refresh: () => Promise<void>;
+} {
+  const { t } = useTranslation();
+  return useMemo(() => {
+    const adapter = new VolumesAdapter();
+    const refresh = async () => {
+      await resourceEvents.refresh(connId, "volumes");
+    };
+    const actions: BulkAction<Volume>[] = [
+      {
+        key: "remove",
+        label: t("Remove"),
+        icon: IconNames.TRASH,
+        intent: Intent.DANGER,
+        destructive: true,
+        eligible: () => true,
+        run: (v) => adapter.remove(v.Name),
+      },
+    ];
+    return { actions, getId: (item: Volume) => item.Name, refresh };
+  }, [connId, t]);
+}

--- a/src/web-app/stores/activityStore.ts
+++ b/src/web-app/stores/activityStore.ts
@@ -234,6 +234,7 @@ systemNotifier.on("activity.api", (event: SystemNotification) => {
     httpStatus: data.httpStatus,
     durationMs: data.durationMs,
     requestBody: data.requestBody,
+    responseBody: data.responseBody,
     curl: data.curl,
     error: data.error,
   } as Partial<ApiEntry>);

--- a/src/web-app/stores/activityTypes.ts
+++ b/src/web-app/stores/activityTypes.ts
@@ -42,6 +42,7 @@ export interface ApiEntry extends ActivityEntryBase {
   durationMs?: number;
   curl?: string;
   requestBody?: string; // JSON-stringified, truncated
+  responseBody?: string; // JSON-stringified, truncated — captured only for non-2xx responses
   error?: string;
 }
 

--- a/src/web-app/stores/uiStore.test.ts
+++ b/src/web-app/stores/uiStore.test.ts
@@ -1,0 +1,21 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useUIStore } from "./uiStore";
+
+describe("uiStore selection", () => {
+  beforeEach(() => {
+    useUIStore.getState().reset();
+  });
+
+  it("sets selected rows per scope", () => {
+    useUIStore.getState().setSelectedRows("containers", ["a", "b"]);
+    expect(useUIStore.getState().selectedRows.containers).toEqual(["a", "b"]);
+    expect(useUIStore.getState().selectedRows.images).toBeUndefined();
+  });
+
+  it("reset clears selected rows", () => {
+    useUIStore.getState().setSelectedRows("containers", ["a", "b"]);
+    useUIStore.getState().reset();
+    expect(useUIStore.getState().selectedRows).toEqual({});
+  });
+});

--- a/src/web-app/stores/uiStore.ts
+++ b/src/web-app/stores/uiStore.ts
@@ -1,6 +1,6 @@
 // web-app/stores/uiStore.ts — client-only UI state (per-screen search term, collapsed groups, selected
-// rows, overlays) that used to live in component useState / Easy-Peasy. Keyed by an arbitrary scope
-// string (usually the screen id) so each screen keeps its own slice. Reset on connection switch.
+// rows, overlays) that used to live in component useState / Easy-Peasy. Keyed by an arbitrary scope string
+// (usually the screen id) so each screen keeps its own slice. Reset on connection switch.
 
 import { create } from "zustand";
 

--- a/src/web-app/themes/shared.css
+++ b/src/web-app/themes/shared.css
@@ -132,7 +132,18 @@ body.bp6-dark [data-table="pods"] .PodState[data-state="Paused"] {
 
 body.bp6-dark .ReactIcon,
 body.bp6-dark .AppLabelIcon {
-  color: #abb3bf;
+  color: #fff;
+}
+
+/* Blueprint (framework) icons default to a muted gray in dark mode that can read as "disabled". Render
+   non-intent icons in the bright foreground color so they match the mdi icon fills; disabled icons stay
+   muted so they still read as disabled. */
+body.bp6-dark .bp6-icon:not([class*="bp6-intent-"]) {
+  color: #fff;
+}
+body.bp6-dark .bp6-button:disabled .bp6-icon:not([class*="bp6-intent-"]),
+body.bp6-dark .bp6-button.bp6-disabled .bp6-icon:not([class*="bp6-intent-"]) {
+  color: #8a93a0;
 }
 
 body.bp6-light .ReactIcon,


### PR DESCRIPTION
## Added

- Bulk (mass) operations on the list screens of Containers, Pods, Machines, Images, Volumes, Networks and Secrets — multi-select rows with delete and lifecycle actions (stop/pause/start/restart).

## Changed

- Notifications & activity log: the bell fills white when there are unread entries (counter badge removed); API response bodies and CLI output now show only for failed calls.