### PR TITLE
Fix replay first frame rendering

### DIFF
--- a/website-src/assets/css/site.css
+++ b/website-src/assets/css/site.css
@@ -76,12 +76,12 @@ section{position:relative}
 .demo-replay-shell{position:relative;width:100%;min-height:360px;overflow:hidden;background:#110817}
 .demo-replay-player{position:absolute;left:0;top:0;overflow:hidden}
 .demo-replay-player .replayer-wrapper{position:absolute;left:0;top:0;background:#110817;z-index:1}
-.demo-replay-player[data-replay-poster="visible"] .replayer-wrapper{opacity:0}
+.demo-replay-player[data-replay-poster="loading"] .replayer-wrapper{opacity:0}
 .demo-replay-player .replayer-wrapper iframe{border:0;background:#110817}
 .demo-replay-player .replayer-mouse{width:14px!important;height:14px!important;margin:-7px 0 0 -7px!important;border:2px solid #fff!important;border-radius:50%!important;background:var(--cyan)!important;box-shadow:0 0 0 3px rgba(19,171,255,.18),0 0 14px rgba(19,171,255,.82)!important;opacity:0!important;transition:opacity .18s ease-out!important}
 .demo-replay-player .replayer-mouse.is-moving{opacity:.9!important}
 .demo-replay-poster{display:block;position:absolute;inset:0;width:100%;height:100%;object-fit:contain;background:#110817;opacity:0;pointer-events:none;transition:opacity .16s ease-out;z-index:3}
-.demo-replay-player[data-replay-poster="visible"] .demo-replay-poster{opacity:1}
+.demo-replay-player[data-replay-poster="loading"] .demo-replay-poster{opacity:1}
 .demo-replay-controls{display:grid;grid-template-columns:auto auto minmax(140px,1fr);align-items:center;gap:12px;padding:12px;border-top:1px solid var(--border);background:rgba(20,8,28,.92)}
 .demo-replay-transport{display:inline-flex;align-items:center;gap:2px;padding:3px;border:1px solid rgba(19,171,255,.32);border-radius:999px;background:rgba(19,171,255,.07)}
 .demo-replay-button{display:inline-flex;align-items:center;justify-content:center;width:30px;height:30px;border:0;border-radius:50%;background:transparent;color:#fff;font-size:12px;line-height:1;cursor:pointer}

--- a/website-src/assets/js/demo-replay.js
+++ b/website-src/assets/js/demo-replay.js
@@ -203,11 +203,7 @@
       } else {
         playing = false;
         setPlayButtonState(false);
-        if (clamped <= 0) {
-          poster.show();
-        } else {
-          poster.hide();
-        }
+        poster.hide();
         replayer.play(clamped);
         window.requestAnimationFrame(() => {
           replayer.pause(clamped);
@@ -302,7 +298,7 @@
     if (poster) {
       target.appendChild(poster);
     }
-    target.dataset.replayPoster = "visible";
+    target.dataset.replayPoster = "loading";
 
     const replayer = new Replayer(replay.events, {
       root: target,
@@ -320,7 +316,7 @@
     const cursor = installCursorIdle(replayer, replay);
     const posterControls = {
       show() {
-        target.dataset.replayPoster = "visible";
+        target.dataset.replayPoster = "loading";
       },
       hide() {
         target.dataset.replayPoster = "hidden";
@@ -328,6 +324,11 @@
     };
     const controls = renderControls(mount, replay, replayer, cursor, posterControls);
     cursor.hide();
+    window.requestAnimationFrame(() => {
+      replayer.pause(0);
+      posterControls.hide();
+      cursor.hide();
+    });
     installKeyboardShortcuts(mount, replay, replayer, controls);
     window.addEventListener("resize", () => resizeReplay(mount, replay, replayer), { passive: true });
   }

--- a/website-src/index.njk
+++ b/website-src/index.njk
@@ -16,7 +16,7 @@ demoReplay: true
   <div class="pd-callout">Looking for the official one made by the Podman team? That's <a href="{{ site.podmanDesktop }}" target="_blank" rel="noopener">Podman Desktop</a> — also great.</div>
   <div class="shot replay-shot" data-demo-replay="/replays/container-desktop-demo.json">
     <div class="demo-replay-shell" data-demo-replay-shell>
-      <div class="demo-replay-player" data-demo-replay-player data-replay-poster="visible" aria-label="Container Desktop demo replay">
+      <div class="demo-replay-player" data-demo-replay-player data-replay-poster="loading" aria-label="Container Desktop demo replay">
         <img class="demo-replay-poster" src="/videos/demo.png" alt="Container Desktop demo preview" />
       </div>
     </div>

--- a/website/assets/css/site.css
+++ b/website/assets/css/site.css
@@ -76,12 +76,12 @@ section{position:relative}
 .demo-replay-shell{position:relative;width:100%;min-height:360px;overflow:hidden;background:#110817}
 .demo-replay-player{position:absolute;left:0;top:0;overflow:hidden}
 .demo-replay-player .replayer-wrapper{position:absolute;left:0;top:0;background:#110817;z-index:1}
-.demo-replay-player[data-replay-poster="visible"] .replayer-wrapper{opacity:0}
+.demo-replay-player[data-replay-poster="loading"] .replayer-wrapper{opacity:0}
 .demo-replay-player .replayer-wrapper iframe{border:0;background:#110817}
 .demo-replay-player .replayer-mouse{width:14px!important;height:14px!important;margin:-7px 0 0 -7px!important;border:2px solid #fff!important;border-radius:50%!important;background:var(--cyan)!important;box-shadow:0 0 0 3px rgba(19,171,255,.18),0 0 14px rgba(19,171,255,.82)!important;opacity:0!important;transition:opacity .18s ease-out!important}
 .demo-replay-player .replayer-mouse.is-moving{opacity:.9!important}
 .demo-replay-poster{display:block;position:absolute;inset:0;width:100%;height:100%;object-fit:contain;background:#110817;opacity:0;pointer-events:none;transition:opacity .16s ease-out;z-index:3}
-.demo-replay-player[data-replay-poster="visible"] .demo-replay-poster{opacity:1}
+.demo-replay-player[data-replay-poster="loading"] .demo-replay-poster{opacity:1}
 .demo-replay-controls{display:grid;grid-template-columns:auto auto minmax(140px,1fr);align-items:center;gap:12px;padding:12px;border-top:1px solid var(--border);background:rgba(20,8,28,.92)}
 .demo-replay-transport{display:inline-flex;align-items:center;gap:2px;padding:3px;border:1px solid rgba(19,171,255,.32);border-radius:999px;background:rgba(19,171,255,.07)}
 .demo-replay-button{display:inline-flex;align-items:center;justify-content:center;width:30px;height:30px;border:0;border-radius:50%;background:transparent;color:#fff;font-size:12px;line-height:1;cursor:pointer}

--- a/website/assets/js/demo-replay.js
+++ b/website/assets/js/demo-replay.js
@@ -203,11 +203,7 @@
       } else {
         playing = false;
         setPlayButtonState(false);
-        if (clamped <= 0) {
-          poster.show();
-        } else {
-          poster.hide();
-        }
+        poster.hide();
         replayer.play(clamped);
         window.requestAnimationFrame(() => {
           replayer.pause(clamped);
@@ -302,7 +298,7 @@
     if (poster) {
       target.appendChild(poster);
     }
-    target.dataset.replayPoster = "visible";
+    target.dataset.replayPoster = "loading";
 
     const replayer = new Replayer(replay.events, {
       root: target,
@@ -320,7 +316,7 @@
     const cursor = installCursorIdle(replayer, replay);
     const posterControls = {
       show() {
-        target.dataset.replayPoster = "visible";
+        target.dataset.replayPoster = "loading";
       },
       hide() {
         target.dataset.replayPoster = "hidden";
@@ -328,6 +324,11 @@
     };
     const controls = renderControls(mount, replay, replayer, cursor, posterControls);
     cursor.hide();
+    window.requestAnimationFrame(() => {
+      replayer.pause(0);
+      posterControls.hide();
+      cursor.hide();
+    });
     installKeyboardShortcuts(mount, replay, replayer, controls);
     window.addEventListener("resize", () => resizeReplay(mount, replay, replayer), { passive: true });
   }

--- a/website/index.html
+++ b/website/index.html
@@ -76,7 +76,7 @@
   <div class="pd-callout">Looking for the official one made by the Podman team? That's <a href="https://podman-desktop.io/" target="_blank" rel="noopener">Podman Desktop</a> — also great.</div>
   <div class="shot replay-shot" data-demo-replay="/replays/container-desktop-demo.json">
     <div class="demo-replay-shell" data-demo-replay-shell>
-      <div class="demo-replay-player" data-demo-replay-player data-replay-poster="visible" aria-label="Container Desktop demo replay">
+      <div class="demo-replay-player" data-demo-replay-player data-replay-poster="loading" aria-label="Container Desktop demo replay">
         <img class="demo-replay-poster" src="/videos/demo.png" alt="Container Desktop demo preview" />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- show the generated rrweb first frame after replay initialization instead of keeping the PNG poster visible
- keep the poster only as a loading fallback
- rebuild the generated website output from website-src

## Verification
- yarn check-types
- yarn lint
- yarn test:run
- yarn build
- Chrome smoke: default replay frame uses rrweb DOM at 1068x718 with scale(1), no page/console errors